### PR TITLE
Change site layout.

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,11 +1,6 @@
 scalaVersion := "2.12.4"
 enablePlugins(MicrositesPlugin)
 
-lazy val scalaFiddleUrl = {
-  if (sys.env.get("TRAVIS_BRANCH").contains("master")) "ignoreForNow"
-  else "http://localhost:8880/"
-}
-
 name := "EvilPlot"
 description := "Combinators for graphics"
 organizationName := "CiBO Technologies"
@@ -13,15 +8,12 @@ organizationHomepage := Some(new java.net.URL("http://www.cibotechnologies.com")
 micrositeGithubOwner := "cibotech"
 micrositeGithubRepo := "evilplot"
 micrositeFooterText := None
-micrositeDocumentationUrl := "/cibotech/evilplot/docs/"
+micrositeDocumentationUrl := "/cibotech/evilplot/scaladoc/jvm/index.html"
 micrositeBaseUrl := "/cibotech/evilplot/"
 micrositeShareOnSocial := false
-// Can turn these off depending on what we want to do...
-// micrositeGithubLinks := false
 micrositeGitterChannel := false
 
 micrositePalette := Map(
-  //"brand-primary" -> "#2B7699",
   "brand-primary" -> "#008080",
   "brand-secondary" -> "#606C71",
   "brand-tertiary" -> "#485155",

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -1,21 +1,24 @@
 options:
+  - title: Home
+  - url: index.html
+
   - title: Getting Started
-    url: docs/index.html
+    url: getting-started.html
 
   - title: Plotting
-    url: docs/plots.html
+    url: plots.html
 
   - title: Drawing API
-    url: docs/drawing-api.html
+    url: drawing-api.html
 
   - title: Custom Renderers
-    url: docs/custom-renderers.html
+    url: custom-renderers.html
 
   - title: Colors
-    url: docs/colors.html
+    url: colors.html
 
   - title: RenderContext
-    url: docs/render-context.html
+    url: render-context.html
 
   - title: Plot Catalog
-    url: docs/plot-catalog.html
+    url: plot-catalog.html

--- a/docs/src/main/tut/colors.md
+++ b/docs/src/main/tut/colors.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: Colors
+position: 6
 ---
 
 # Colors

--- a/docs/src/main/tut/custom-renderers.md
+++ b/docs/src/main/tut/custom-renderers.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: Custom Renderers
+position: 5
 ---
 
 # Custom Renderers

--- a/docs/src/main/tut/drawing-api.md
+++ b/docs/src/main/tut/drawing-api.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: Drawing API
+position: 4
 ---
 # Low-Level Drawing API
 

--- a/docs/src/main/tut/getting-started.md
+++ b/docs/src/main/tut/getting-started.md
@@ -1,12 +1,13 @@
 ---
 layout: docs
 title: Getting Started
+position: 2
 ---
 # Getting Started
 
 To get going with EvilPlot, you'll need to add it to your build.
 ```scala
-resolvers += Seq(Resolver.bintrayRepo("cibotech", "public"))
+resolvers += Resolver.bintrayRepo("cibotech", "public")
 libraryDependencies += "com.cibo" %% "evilplot" % "0.2.0" // Use %%% instead of %% if you're using ScalaJS
 ```
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -1,7 +1,8 @@
 ---
 layout: home
-title: "EvilPlot"
+title: "Home"
 section: "home"
+position: 1
 ---
 
 EvilPlot is a combinator-based data visualization library written in Scala.
@@ -12,9 +13,9 @@ plots out of those simpler ones.
 Everything is backed by a high-level two-dimensional drawing API, which makes it easy to invent new components for your
 plots from scratch.
 
-Check out our [documentation](/cibotech/evilplot/docs/index.html), where you can learn just how easy and awesome it is
+Check out our [documentation](/cibotech/evilplot/getting-started.html), where you can learn just how easy and awesome it is
 to get going with EvilPlot.
-Alternatively, skip straight to the [Plot Catalog](/cibotech/evilplot/docs/plot-catalog.html) for some examples of what
+Alternatively, skip straight to the [Plot Catalog](/cibotech/evilplot/plot-catalog.html) for some examples of what
 EvilPlot can do, along with code.
 You can also take a look at the complete [API documentation](/cibotech/evilplot/scaladoc/jvm/index.html)
 or the source on [GitHub](https://www.github.com/cibotech/evilplot).

--- a/docs/src/main/tut/plot-catalog.md
+++ b/docs/src/main/tut/plot-catalog.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: Plot Catalog
+position: 8
 ---
 # Plot Catalog
 

--- a/docs/src/main/tut/plots.md
+++ b/docs/src/main/tut/plots.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: Plotting
+position: 3
 ---
 
 # Plots
@@ -25,10 +26,9 @@ Before, we passed the defaults for all parameters in `ScatterPlot` and let our t
 But what if we want to color each point differently depending on the value of another variable? That's where the
 `pointRenderer` argument comes in.
 
-<!-- Link to Scaladoc here. -->
 A `PointRenderer` tells your plot how to draw the data. When we don't pass one into `ScatterPlot`, we use
 `PointRenderer.default()`, which plots each item in the `data` sequence as a disc filled with the color in
-`theme.colors.fill`. But, there are a bunch more [`PointRenderer`s to choose from](deadlink).
+`theme.colors.fill`. But, there are a bunch more [`PointRenderer`s to choose from](/cibotech/evilplot/scaladoc/jvm/com/cibo/evilplot/plot/renderers/PointRenderer$.html).
 
 <div class="row">
 <div class="col-md-6" markdown="1">

--- a/docs/src/main/tut/render-context.md
+++ b/docs/src/main/tut/render-context.md
@@ -1,9 +1,10 @@
 ---
 layout: docs
 title: Render Context 
+position: 7
 ---
 
-# `RenderContext`
+# RenderContext
 
 A `RenderContext` is the final target for all drawing operations in EvilPlot--it's where a constructed `Drawable` goes
 to ultimately be put on a screen. EvilPlot provides a `RenderContext` for each supported platform.


### PR DESCRIPTION
This changes the documentation site to have a menu bar on the home page, and have the "Documentation" link at top right point to Scaladoc instead of the tutorial. This is more in line with other uses of this microsites documentation tool that I have seen.