### PR TITLE
fix extents in Polygons and Paths

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
@@ -97,8 +97,8 @@ object Path {
     val minY = points.map(_.y).min
     Translate(new Path(points.map{x=> Point(x.x - minX, x.y - minY)},strokeWidth), minX, minY)
   }
-  implicit val encoder: Encoder[Path] = Encoder.forProduct2("points", "strokeWidth"){x => (x.points, x.strokeWidth)}
-  implicit val decoder: Decoder[Path] = Decoder.forProduct2("points", "strokeWidth")(new Path(_,_))
+  implicit val encoder: Encoder[Path] = Encoder.forProduct2("p", "s"){x => (x.points, x.strokeWidth)}
+  implicit val decoder: Decoder[Path] = Decoder.forProduct2("p", "s")(new Path(_,_))
 }
 
 /** A filled polygon.
@@ -112,8 +112,8 @@ final case class Polygon(boundary: Seq[Point]) extends Drawable {
   def draw(context: RenderContext): Unit = if (boundary.nonEmpty) context.draw(this) else ()
 }
 object Polygon {
-  implicit val encoder: Encoder[Polygon] = Encoder.forProduct1("boundary"){x=> x.boundary}
-  implicit val decoder: Decoder[Polygon] = Decoder.forProduct1("boundary")(new Polygon(_))
+  implicit val encoder: Encoder[Polygon] = Encoder.forProduct1("b"){x=> x.boundary}
+  implicit val decoder: Decoder[Polygon] = Decoder.forProduct1("b")(new Polygon(_))
 
   def clipped(boundary: Seq[Point], extent: Extent): Drawable = {
     Polygon(Clipping.clipPolygon(boundary, extent))

--- a/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
@@ -87,7 +87,7 @@ final case class Path(points: Seq[Point], strokeWidth: Double) extends Drawable 
   private lazy val xS: Seq[Double] = points.map(_.x)
   private lazy val yS: Seq[Double] = points.map(_.y)
   lazy val extent: Extent =
-    if (points.nonEmpty) Extent(xS.max - xS.min, yS.max - yS.min) else Extent(0, 0)
+    if (points.nonEmpty) Extent(xS.max , yS.max) else Extent(0, 0)
   def draw(context: RenderContext): Unit = if (points.nonEmpty) context.draw(this) else ()
 }
 object Path {

--- a/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
@@ -91,8 +91,14 @@ final case class Path(points: Seq[Point], strokeWidth: Double) extends Drawable 
   def draw(context: RenderContext): Unit = if (points.nonEmpty) context.draw(this) else ()
 }
 object Path {
-  implicit val encoder: Encoder[Path] = deriveEncoder[Path]
-  implicit val decoder: Decoder[Path] = deriveDecoder[Path]
+
+  def apply(points: Seq[Point], strokeWidth: Double) : Drawable = {
+    val minX = points.map(_.x).min
+    val minY = points.map(_.y).min
+    Translate(new Path(points.map{x=> Point(x.x - minX, x.y - minY)},strokeWidth), minX, minY)
+  }
+  implicit val encoder: Encoder[Path] = Encoder.forProduct2("points", "strokeWidth"){x => (x.points, x.strokeWidth)}
+  implicit val decoder: Decoder[Path] = Decoder.forProduct2("points", "strokeWidth")(new Path(_,_))
 }
 
 /** A filled polygon.
@@ -102,15 +108,21 @@ final case class Polygon(boundary: Seq[Point]) extends Drawable {
   private lazy val xS: Seq[Double] = boundary.map(_.x)
   private lazy val yS: Seq[Double] = boundary.map(_.y)
   lazy val extent: Extent =
-    if (boundary.nonEmpty) Extent(xS.max - xS.min, yS.max - yS.min) else Extent(0, 0)
+    if (boundary.nonEmpty) Extent(xS.max, yS.max) else Extent(0, 0)
   def draw(context: RenderContext): Unit = if (boundary.nonEmpty) context.draw(this) else ()
 }
 object Polygon {
-  implicit val encoder: Encoder[Polygon] = deriveEncoder[Polygon]
-  implicit val decoder: Decoder[Polygon] = deriveDecoder[Polygon]
+  implicit val encoder: Encoder[Polygon] = Encoder.forProduct1("boundary"){x=> x.boundary}
+  implicit val decoder: Decoder[Polygon] = Decoder.forProduct1("boundary")(new Polygon(_))
 
   def clipped(boundary: Seq[Point], extent: Extent): Drawable = {
     Polygon(Clipping.clipPolygon(boundary, extent))
+  }
+
+  def apply(boundary: Seq[Point]) :Drawable = {
+      val minX = boundary.map(_.x).min
+      val minY = boundary.map(_.y).min
+      Translate(new Polygon(boundary.map{x=> Point(x.x - minX, x.y - minY)}), minX, minY)
   }
 }
 


### PR DESCRIPTION
As it is, Polygons and paths report extents that represent the distance between the maximum and minimum X and Y points within their shape. That's a good guess of what an extent is: unfortunately, the renderer believes that everything is drawn between 0,0 and said extents. This means that a polygon that is far away from zero and is near the edge of the plot will never be rendered: For instance, try to render this:

```
Polygon(Seq(Point(0,0), Point(0,100),Point(100,0))).behind(
    Style(Polygon(Seq(Point(30,0), Point(30,100),Point(50,100), Point(50,0))),RGB(200,180,20)).behind(
     Style(Polygon(Seq(Point(72,2), Point(75,98), Point(186,200), Point(506,2))), RGB(0,200,200)).behind(
       Style(Polygon(Seq(Point(62,7), Point(62,48), Point(86,48), Point(86,7))), RGB(0,255,0))

     )
      )
    )
    .write(new File("blah.png"))
```

And you will see how one of the polygons is heavily clipped.

My attempt at a fix is to try to make polygons live closer to 0,0, regardless of the user's input. To accomplish this, calls to Polygon and Path's apply method try to move the drawable's points to be near 0,0, and then apply a translation to put them back to where the user originally intended. This produces a polygon that will have the old extents, but now is wrapped by a translation that will have the correct extents.

This solution is a bit harder than just making the bounding box start at 0,0, but this also allows for introspection on the scene's graph, if we ever wanted to do things like efficiently render only a subset of said graph.

An unfortunate loss in this case is circe's default encoders and decoders, as they do not like objects that override the apply method: I went for the next best option, which isn't great, but seemed tolerable to me.

