### PR TITLE
Remove scaling and padding on JVM write.

### DIFF
--- a/jvm/src/it/scala/com/cibo/evilplot/WriteOutDemoPlots.scala
+++ b/jvm/src/it/scala/com/cibo/evilplot/WriteOutDemoPlots.scala
@@ -3,6 +3,7 @@ package com.cibo.evilplot
 import java.io.File
 import java.nio.file.{Files, Paths}
 
+import com.cibo.evilplot.geometry.fit
 import com.cibo.evilplot.demo.DemoPlots
 import javax.imageio.ImageIO
 import org.scalatest.{FunSpec, Matchers}
@@ -32,7 +33,7 @@ class WriteOutDemoPlots extends FunSpec with Matchers {
   describe("Demo Plots") {
     it("is generated") {
       for { (plot, name) <- plots } {
-        val bi = plot.asBufferedImage
+        val bi = fit(plot.padAll(10), plot.extent * 4).asBufferedImage(plot.extent * 4)
         ImageIO.write(bi, "png", new File(s"${tmpPath.toAbsolutePath.toString}/$name.png"))
       }
     }

--- a/jvm/src/main/scala/com/cibo/evilplot/package.scala
+++ b/jvm/src/main/scala/com/cibo/evilplot/package.scala
@@ -34,23 +34,24 @@ import java.awt.image.BufferedImage
 
 import com.cibo.evilplot.geometry._
 import javax.imageio.ImageIO
+
 package object evilplot {
   implicit class AwtDrawableOps(r: Drawable) {
 
-    /** Return a BufferedImage containing the contents of this Drawable. */
-    def asBufferedImage: BufferedImage = {
-      val scale = 4.0
-      val paddingHack = 20
+    def asBufferedImage(extent: Extent): BufferedImage = {
       val bi = new BufferedImage(
-        (r.extent.width * scale.toInt).toInt,
-        (r.extent.height * scale).toInt,
+        extent.width.toInt,
+        extent.height.toInt,
         BufferedImage.TYPE_INT_ARGB)
       val gfx = bi.createGraphics()
-      gfx.scale(scale, scale)
-      val padded = r.padAll(paddingHack / 2)
-      fit(padded, r.extent).draw(Graphics2DRenderContext(gfx))
+      r.draw(Graphics2DRenderContext(gfx))
       gfx.dispose()
       bi
+    }
+
+    /** Return a BufferedImage containing the contents of this Drawable. */
+    def asBufferedImage: BufferedImage = {
+      asBufferedImage(r.extent)
     }
 
     /** Write a Drawable to a file as a PNG. */


### PR DESCRIPTION
These operations can be applied directly to drawables before writing.

Allowed providing an extent to `asBufferedImage` so that the demo plot images render with the expected size (an update/alternative to `fit` that handles this padding might be useful)