### PR TITLE
support color clipping at the edge of gradients

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/colors/Coloring.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/Coloring.scala
@@ -188,4 +188,14 @@ object ContinuousColoring {
         )
       }
     }
+  /** Convenience coloring method when we know exactly what the values of the gradients are.
+    * @param colors the colors to use as interpolation points
+    * @param min min value
+    * @param max max override for the data
+    */
+  def gradient(colors: Seq[Color],
+               min: Double,
+               max: Double,
+               gradientMode: GradientMode
+              )(implicit theme: Theme) : Double => Color = gradient(colors, Some(min), Some(max), gradientMode)(Seq.empty)
 }

--- a/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
@@ -46,7 +46,7 @@ private[colors] object GradientUtils {
     if (numGradients == 0) (_: Double) => colors.head
     else {
       val singleGradientExtent = (max - min) / numGradients
-      val gradients: Seq[PartialFunction[Double, HSLA]] = Seq.tabulate(numGradients) { i =>
+      val gradients: Seq[PartialFunction[Double, Color]] = Seq.tabulate(numGradients) { i =>
         val lower = min + i * singleGradientExtent
         singleGradient(
           lower - 1e-5,
@@ -64,17 +64,23 @@ private[colors] object GradientUtils {
     startColor: Color,
     endColor: Color,
     mode: GradientMode
-  ): PartialFunction[Double, HSLA] = {
-    case d if d >= minValue && d <= maxValue =>
-      import mode._
-      val (r1, g1, b1, a1) = rgba(startColor)
-      val (r2, g2, b2, a2) = rgba(endColor)
-      val range = maxValue - minValue
-      val interpolationCoefficient = (d - minValue) / range
-      val r = interpolate(inverse(r1), inverse(r2), interpolationCoefficient)
-      val g = interpolate(inverse(g1), inverse(g2), interpolationCoefficient)
-      val b = interpolate(inverse(b1), inverse(b2), interpolationCoefficient)
-      val a = interpolate(a1, a2, interpolationCoefficient)
-      RGBA((255 * forward(r)).toInt, (255 * forward(g)).toInt, (255 * forward(b)).toInt, a)
+  ): PartialFunction[Double, Color] = {
+
+    {
+      case d if d > minValue && d < maxValue =>
+        import mode._
+        val (r1, g1, b1, a1) = rgba(startColor)
+        val (r2, g2, b2, a2) = rgba(endColor)
+        val range = maxValue - minValue
+        val interpolationCoefficient = (d - minValue) / range
+        val r = interpolate(inverse(r1), inverse(r2), interpolationCoefficient)
+        val g = interpolate(inverse(g1), inverse(g2), interpolationCoefficient)
+        val b = interpolate(inverse(b1), inverse(b2), interpolationCoefficient)
+        val a = interpolate(a1, a2, interpolationCoefficient)
+        RGBA((255 * forward(r)).toInt, (255 * forward(g)).toInt, (255 * forward(b)).toInt, a)
+      case d if d <= minValue => startColor
+      case d if d >= maxValue => endColor
+    }
   }
+
 }

--- a/shared/src/test/scala/com/cibo/evilplot/colors/ColoringSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/colors/ColoringSpec.scala
@@ -57,6 +57,16 @@ class ColoringSpec extends FunSpec with Matchers {
       val coloring = gradient(data)
       data.foreach(d => noException shouldBe thrownBy(coloring(d)))
     }
+
+    it("should behave properly when asked to render past the edge") {
+      val gradient = ContinuousColoring.gradient(HTMLNamedColors.red, HTMLNamedColors.blue)
+      val coloring = gradient(Seq(1.0,5.0))
+      coloring(1.0) shouldBe HTMLNamedColors.red
+     // coloring(0.0) shouldBe HTMLNamedColors.red
+      coloring(5.0) shouldBe HTMLNamedColors.blue
+      coloring(6.0) shouldBe HTMLNamedColors.blue
+
+    }
   }
   describe("coloring from the theme") {
     import com.cibo.evilplot.plot.aesthetics.DefaultTheme.{DefaultColors => AesColors}


### PR DESCRIPTION
In many real world charts, we don't necessarily want only the very extreme points to have the edge colors: Imagine a gaussian distribution plotted using the original gradient: We'd get a big contrast between the 6th sigma, the 5th sigma and the 4th sigma among outliers, but the large majority of the distribution would become a same-ish mess in the middle. This is rarely what you want in a chart.

We really could use more fun gradient functions, not unlike those we know and love from QGis, but until then, at the very least, allowing a chart writer to 'clip, the edge of the charts, after which everything is either the lowest or the highest color, allows for better, cheap chart improvements. The existing code allowed a developer to enter maximum and minimum values prior to plotting, but had the unfortunate behavior of exploding if handed a value outside of those bounds. Since I do not see why we'd want an exception instead of clipping to the edge values provided, I provided a patch for this.

As an added bonus, I saw that gradients return a Seq(Double) => Double => Color regardless of whether that Seq is going to be used or not, and when a minimum and a maximum are provided, it will be useless. Thus I built a utility method, that instead of taking options of max and mins, requires actual values, and not only cuts on boxing (and therefore our risk of chronic traumatic encephalopathy), but also returns a Double => Color, which is what the callers would want anyway.

