### PR TITLE
Fix to markers pushing border plots around

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/plot/components/BorderPlot.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/components/BorderPlot.scala
@@ -59,8 +59,9 @@ case class BorderPlot(
         val borderExtent = Extent(extent.height, borderSize)
         border
           .xbounds(plot.ybounds)
-          .copy(xtransform = plot.ytransform)
+          .copy(xtransform = plot.xtransform)
           .render(borderExtent)
+          .resize(borderExtent)
           .rotated(270)
       case Position.Right =>
         val borderExtent = Extent(extent.height, borderSize)
@@ -68,6 +69,7 @@ case class BorderPlot(
           .xbounds(plot.ybounds)
           .copy(xtransform = plot.xtransform)
           .render(borderExtent)
+          .resize(borderExtent)
           .rotated(90)
           .flipY
       case _ =>


### PR DESCRIPTION
These changes fix two bugs:

1. Markers that exceed the size of the border plot push the border plot around.
<img width="100" alt="screen shot 2018-06-13 at 11 24 13 am" src="https://user-images.githubusercontent.com/13050409/41361228-8879f8d2-6efc-11e8-94e1-7ec8e6659bd8.png">

2. The leftPlot had the wrong xtransform, causing the x-axis coordinates to be shrunk by a large factor.
<img width="100" alt="screen shot 2018-06-13 at 11 24 43 am" src="https://user-images.githubusercontent.com/13050409/41361244-9021d762-6efc-11e8-82a5-d7a5bea25bf9.png">

The fixed plot looks like this:
<img width="100" alt="screen shot 2018-06-13 at 11 21 03 am" src="https://user-images.githubusercontent.com/13050409/41361269-9da986dc-6efc-11e8-9b22-e496f770c8b4.png">

