### PR TITLE
rename root project to help intellij

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ crossScalaVersions in ThisBuild := Settings.versions.crossScalaVersions
 scalaVersion in ThisBuild := crossScalaVersions.value.head
 scalacOptions in ThisBuild ++= Settings.scalacOptions
 
-lazy val root = project
+lazy val `evilplot-root` = project
   .in(file("."))
   .aggregate(evilplotJVM, evilplotJS, assetJVM, evilplotRunner)
   .settings(


### PR DESCRIPTION
This tries to fix an annoyance for intellij users. It should not be noticeable for pretty much anyone else.

IntelliJ Idea names its sbt projects with the same name as the Project() on the root dir, or the variable name that represents it. Therefore, without this change, it's named Root. This is quite the annoyance when looking at previously open projects, as one has to remember that root means evilplot. This gets even worse if one works on other scalajs projects that follow the same pattern.

Everything else should be unaffected, as all we are doing is changing the name of a build variable