### PR TITLE
Add a named BarRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Changes since last release]
 
+### Added
+- `BarRenderer.named`, which allows specifying a name and color to the legend context, especially in histograms.
+
 ## [0.3.1] - 2018-06-14
 ### Added
 - Ability to create data positioned plot components.

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -111,6 +111,23 @@ object DemoPlots {
       .render(plotAreaSize)
   }
 
+  lazy val multiOverlayHistogram: Drawable = {
+    import scala.util.Random
+    def data(offset: Double): Seq[Double] = Seq.fill(200)(offset + Random.nextDouble())
+    Overlay
+      .fromSeq((0 to 3).zip(theme.colors.stream).collect {
+        case (offset, c: HSLA) =>
+          val color = c.copy(opacity = 0.3)
+          Histogram(
+            data(offset),
+            bins = 10,
+            barRenderer = Some(BarRenderer.named(color = Some(color), name = Some(offset.toString)))
+          )
+      })
+      .rightLegend()
+      .render()
+  }
+
   lazy val scatterPlot: Drawable = {
     val points = Seq.fill(150)(Point(Random.nextDouble(), Random.nextDouble())) :+ Point(0.0, 0.0)
     val years = Seq.fill(150)(Random.nextDouble()) :+ 1.0

--- a/shared/src/main/scala/com/cibo/evilplot/plot/BarChart.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/BarChart.scala
@@ -77,7 +77,8 @@ object BarChart {
     clusterSpacing: Double
   ) extends PlotRenderer {
 
-    override def legendContext: LegendContext = LegendContext.combine(data.map(_.legendContext))
+    override def legendContext: LegendContext =
+      LegendContext.combine(barRenderer.legendContext.toSeq ++ data.map(_.legendContext))
 
     def render(plot: Plot, plotExtent: Extent)(implicit theme: Theme): Drawable = {
       if (data.isEmpty) {

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Histogram.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Histogram.scala
@@ -92,6 +92,10 @@ object Histogram {
         EmptyDrawable()
       }
     }
+
+    override val legendContext: LegendContext =
+      barRenderer.legendContext.getOrElse(LegendContext.empty)
+
   }
 
   /** Create a histogram.

--- a/shared/src/main/scala/com/cibo/evilplot/plot/renderers/BarRenderer.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/renderers/BarRenderer.scala
@@ -33,10 +33,11 @@ package com.cibo.evilplot.plot.renderers
 import com.cibo.evilplot.colors.Color
 import com.cibo.evilplot.geometry._
 import com.cibo.evilplot.plot.aesthetics.Theme
-import com.cibo.evilplot.plot.{Bar, Plot}
+import com.cibo.evilplot.plot.{Bar, LegendContext, Plot}
 
 trait BarRenderer extends PlotElementRenderer[Bar] {
   def render(plot: Plot, extent: Extent, category: Bar): Drawable
+  def legendContext: Option[LegendContext] = None
 }
 
 object BarRenderer {
@@ -47,6 +48,27 @@ object BarRenderer {
   )(implicit theme: Theme): BarRenderer = new BarRenderer {
     def render(plot: Plot, extent: Extent, bar: Bar): Drawable = {
       Rect(extent.width, extent.height).filled(color.getOrElse(theme.colors.bar))
+    }
+  }
+
+  /** A BarRenderer that assigns a single name to this bar. */
+  def named(
+    color: Option[Color] = None,
+    name: Option[String] = None,
+    legendElement: Option[Drawable] = None
+  )(implicit theme: Theme): BarRenderer = new BarRenderer {
+    def render(plot: Plot, extent: Extent, bar: Bar): Drawable = {
+      Rect(extent.width, extent.height).filled(color.getOrElse(theme.colors.bar))
+    }
+
+    override def legendContext: Option[LegendContext] = name.map { n =>
+      LegendContext.single(
+        element = legendElement.getOrElse {
+          val legSize = theme.fonts.legendLabelSize
+          Rect(legSize, legSize).filled(color.getOrElse(theme.colors.bar))
+        },
+        label = n
+      )
     }
   }
 


### PR DESCRIPTION
This adds `BarRenderer.named`, which allows specifying a name and color to the legend context, especially in histograms.