### PR TITLE
WIP flipping components in border plots.

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/plot/components/BorderPlot.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/components/BorderPlot.scala
@@ -32,6 +32,7 @@ package com.cibo.evilplot.plot.components
 
 import com.cibo.evilplot.geometry.{Drawable, Extent}
 import com.cibo.evilplot.plot.Plot
+import com.cibo.evilplot.plot.Plot.Transformer
 import com.cibo.evilplot.plot.aesthetics.Theme
 
 case class BorderPlot(
@@ -39,7 +40,16 @@ case class BorderPlot(
   borderSize: Double,
   border: Plot
 ) extends PlotComponent {
+  case object InvertXTransformer extends Transformer {
+    def apply(plot: Plot, plotExtent: Extent): Double => Double = {
+      val scale = plotExtent.width / plot.xbounds.range
+      (x: Double) =>
+        plotExtent.width - (x - plot.xbounds.min) * scale
+    }
+  }
+
   override def size(plot: Plot): Extent = Extent(borderSize, borderSize)
+
   def render(plot: Plot, extent: Extent)(implicit theme: Theme): Drawable = {
     position match {
       case Position.Top =>
@@ -67,11 +77,10 @@ case class BorderPlot(
         val borderExtent = Extent(extent.height, borderSize)
         border
           .xbounds(plot.ybounds)
-          .copy(xtransform = plot.xtransform)
+          .setXTransform(InvertXTransformer, false)
           .render(borderExtent)
           .resize(borderExtent)
           .rotated(90)
-          .flipY
       case _ =>
         border.render(extent)
     }


### PR DESCRIPTION
Posting this for feedback. Since there are manual work-arounds for this issue (and this is a breaking change), It's probably worth holding off on merge until something else requires a release (I have some related breaking changes to axes/scaling in progress).

Reversing data values with a transformer in Right BorderPlots. I did
not add this change to Bottom BorderPlots since there are other issues
there: components rotated upside-down (which doesn't seem as intuitive
as the rotated Right BorderPlot components)

Examples with right & bottom border plots + components (only rightPlot is updated). I added the axis on the border plots to illustrate transformer vs. drawable flip (though it's still "broken" in both cases currently).
Original (drawable flip):
<img width="324" alt="screen shot 2018-06-29 at 9 31 40 am" src="https://user-images.githubusercontent.com/1902485/42095298-36d44826-7b80-11e8-83eb-ae08f4fdfb19.png">

Updated (data transformer):
<img width="333" alt="screen shot 2018-06-29 at 9 26 58 am" src="https://user-images.githubusercontent.com/1902485/42095307-3c1af366-7b80-11e8-8baf-d5e51e12184c.png">