### PR TITLE
Re-enable build for Scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 scala:
     - 2.12.4
-
+    - 2.11.12
+    
 jdk:
     - oraclejdk8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Changes since last release]
+### Added
+- Build for Scala 2.11
 
 ## [0.3.2] - 2018-06-28
 ### Added

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -8,11 +8,12 @@ object Settings {
     "-deprecation",
     "-unchecked",
     "-feature",
-    "-Xfatal-warnings"
+    "-Xfatal-warnings",
+    "-Xsource:2.12"
   )
 
   object versions { //scalastyle:ignore
-    val crossScalaVersions = Seq("2.12.4")
+    val crossScalaVersions = Seq("2.12.4", "2.11.12")
     val scalaDom = "0.9.3"
     val scalaTest = "3.0.1"
     val scalactic = "3.0.1"

--- a/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/geometry/Drawable.scala
@@ -98,7 +98,9 @@ object Path {
     Translate(new Path(points.map{x=> Point(x.x - minX, x.y - minY)},strokeWidth), minX, minY)
   }
   implicit val encoder: Encoder[Path] = Encoder.forProduct2("p", "s"){x => (x.points, x.strokeWidth)}
-  implicit val decoder: Decoder[Path] = Decoder.forProduct2("p", "s")(new Path(_,_))
+  implicit val decoder: Decoder[Path] = Decoder.forProduct2("p", "s")(
+    (points: Seq[Point], strokeWidth: Double) => new Path(points, strokeWidth)
+  )
 }
 
 /** A filled polygon.
@@ -112,8 +114,10 @@ final case class Polygon(boundary: Seq[Point]) extends Drawable {
   def draw(context: RenderContext): Unit = if (boundary.nonEmpty) context.draw(this) else ()
 }
 object Polygon {
-  implicit val encoder: Encoder[Polygon] = Encoder.forProduct1("b"){x=> x.boundary}
-  implicit val decoder: Decoder[Polygon] = Decoder.forProduct1("b")(new Polygon(_))
+  implicit val encoder: Encoder[Polygon] = Encoder.forProduct1("b"){x => x.boundary}
+  implicit val decoder: Decoder[Polygon] = Decoder.forProduct1("b")(
+    (boundary: Seq[Point]) => new Polygon(boundary)
+  )
 
   def clipped(boundary: Seq[Point], extent: Extent): Drawable = {
     Polygon(Clipping.clipPolygon(boundary, extent))


### PR DESCRIPTION
Re-enable the Scala 2.11 build. Adding the "-Xsource-2.12" compiler flag allows the custom apply methods on `Path` and `Polygon` to exist: https://github.com/scala/scala/releases/tag/v2.11.11

closes https://github.com/cibotech/evilplot/issues/23
