### PR TITLE
box plot displays a line when variance is zero

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/plot/BoxPlot.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/BoxPlot.scala
@@ -55,7 +55,12 @@ private final case class BoxPlotRenderer(
             val boxHeight = ytransformer(summary.lowerWhisker) - ytransformer(summary.upperWhisker)
             val boxWidth = xtransformer(plot.xbounds.min + index + 1) - x - spacing / 2
 
-            val box = boxRenderer.render(plot, Extent(boxWidth, boxHeight), summary)
+            val box = {
+              if (boxHeight != 0) boxRenderer.render(plot, Extent(boxWidth, boxHeight), summary)
+              else {
+                StrokeStyle(Line(boxWidth, theme.elements.strokeWidth), theme.colors.path)
+              }
+            }
 
             val points = summary.outliers.map { pt =>
               pointRenderer


### PR DESCRIPTION
When a `Seq[Double]` passed to a boxplot has no variance, boxplot will render a line at the median of the data instead of rendering nothing.

Example:
```
val data = Seq(
      Seq[Double](-1,2), 
      Seq[Double](1,1,1), 
      Seq[Double](3,4))
BoxPlot(data)
      .standard()
      .render(
```
<img width="961" alt="screen shot 2018-07-11 at 3 38 48 pm" src="https://user-images.githubusercontent.com/13050409/42595580-be8ad18c-8520-11e8-9110-e5f4d8ec3856.png">
