### PR TITLE
Fix multistop gradients

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -88,19 +88,32 @@ object DemoPlots {
   }
 
   lazy val axesTesting: Drawable = {
-    val points = Seq(Point(1, 1), Point(1.5, 1.1), Point(2.5,1.5), Point(2.9, 2.5), Point(3, 3))
+    val points = Seq(Point(1, 1), Point(1.5, 1.1), Point(2.5, 1.5), Point(2.9, 2.5), Point(3, 3))
     val filler = Seq("Lorem", "ipsum", "dolor", "sit", "amet", "consectetur")
     LinePlot(points)
-      // Note discrete axes are still "banded/boxed" such that ticks don't point to values, but to the center of a
-      // band for that value
-      .discreteAxis(Seq("foo", "bar", "baz"), Seq(1d, 2, 10), Position.Bottom, updatePlotBounds = false)
-      .discreteAxis(filler, filler.indices.map(_.toDouble), Position.Right, updatePlotBounds = false)
-      .continuousAxis(plot => plot.xbounds, Position.Top, tickRenderer = Some(TickRenderer.axisTickRenderer(
+    // Note discrete axes are still "banded/boxed" such that ticks don't point to values, but to the center of a
+    // band for that value
+      .discreteAxis(
+        Seq("foo", "bar", "baz"),
+        Seq(1d, 2, 10),
+        Position.Bottom,
+        updatePlotBounds = false)
+      .discreteAxis(
+        filler,
+        filler.indices.map(_.toDouble),
+        Position.Right,
+        updatePlotBounds = false)
+      .continuousAxis(
+        plot => plot.xbounds,
         Position.Top,
-        rotateText = 315
-      )))
+        tickRenderer = Some(
+          TickRenderer.axisTickRenderer(
+            Position.Top,
+            rotateText = 315
+          )))
       .continuousAxis(_ => Bounds(0, 100000), Position.Left, updatePlotBounds = false)
-      .xGrid().yGrid()
+      .xGrid()
+      .yGrid()
       .frame()
       .render(Extent(400, 300))
   }
@@ -185,8 +198,15 @@ object DemoPlots {
   lazy val scatterPlot: Drawable = {
     val points = Seq.fill(150)(Point(Random.nextDouble(), Random.nextDouble())) :+ Point(0.0, 0.0)
     val years = Seq.fill(150)(Random.nextDouble()) :+ 1.0
-    ScatterPlot(points, pointRenderer = Some(PointRenderer.depthColor(years, None, None)))
-      .standard()
+    ScatterPlot(
+      points,
+      pointRenderer = Some(
+        PointRenderer.depthColor(
+          years,
+          Some(ContinuousColoring
+            .gradient3(HTMLNamedColors.green, HTMLNamedColors.yellow, HTMLNamedColors.red)),
+          None))
+    ).standard()
       .xLabel("x")
       .yLabel("y")
       .trend(1, 0)

--- a/shared/src/test/scala/com/cibo/evilplot/colors/ColoringSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/colors/ColoringSpec.scala
@@ -50,6 +50,17 @@ class ColoringSpec extends FunSpec with Matchers {
         GradientUtils.multiGradient(Seq(), 0, 100, GradientMode.Linear))
     }
 
+    it("should build multistop gradients") {
+      import HTMLNamedColors.{red, yellow, green}
+      val min = 0
+      val max = 2
+      val colors = Seq(red, yellow, green)
+      val gradient = GradientUtils.multiGradient(colors, min, max, GradientMode.Linear)
+      gradient(min) should ===(colors.head)
+      gradient(1) should ===(colors(1))
+      gradient(max) should ===(colors(2))
+    }
+
     it("should return a function that works between min and max") {
       val data: Seq[Double] = Seq(0, 5, 20, 40, 70, 100)
       val gradient = ContinuousColoring.gradient(HTMLNamedColors.red, HTMLNamedColors.blue)
@@ -60,12 +71,10 @@ class ColoringSpec extends FunSpec with Matchers {
 
     it("should behave properly when asked to render past the edge") {
       val gradient = ContinuousColoring.gradient(HTMLNamedColors.red, HTMLNamedColors.blue)
-      val coloring = gradient(Seq(1.0,5.0))
+      val coloring = gradient(Seq(1.0, 5.0))
       coloring(1.0) shouldBe HTMLNamedColors.red
-     // coloring(0.0) shouldBe HTMLNamedColors.red
       coloring(5.0) shouldBe HTMLNamedColors.blue
       coloring(6.0) shouldBe HTMLNamedColors.blue
-
     }
   }
   describe("coloring from the theme") {


### PR DESCRIPTION
Multistop gradients were broken because the functionality was relying on `singleGradient`s being `PartialFunction[Double, Color]`s that were not defined outside of their range, then doing an `orElse` down the chain to pick the right one, but `singleGradient` had changed to be defined beyond the endpoints.

This has been changed by making the `multiGradient` function be defined beyond the endpoints, rather than the `singleGradient` partial function, plus adding a `singleGradientComplete` that is actually defined beyond the endpoints. This isn't a breaking change since `singleGradient` hasn't been a public method in any released version of EvilPlot.