### PR TITLE
Fix ScalaDoc generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
         - $HOME/.sbt/boot/
 
 script:
-    - sbt ++$TRAVIS_SCALA_VERSION scalastyle test headerCheck test:headerCheck
+    - sbt ++$TRAVIS_SCALA_VERSION scalastyle test headerCheck test:headerCheck doc
 
 notifications:
   email: false

--- a/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
@@ -38,7 +38,7 @@ object GradientUtils {
     * @param min the minimum of the range over which to create the gradient
     * @param max the maximum of the range over which to create the gradient
     * @param mode the [[GradientMode]]
-    * @return a [[Double => Color]] that returns an interpolated color for doubles
+    * @return a Double => Color that returns an interpolated color for doubles
     *         in [min, max] and the respective endpoints for all other doubles.
     */
   def multiGradient(
@@ -73,7 +73,7 @@ object GradientUtils {
   }
 
   /** Create a gradient between two colors.
-    * @return A [[PartialFunction[Double, Color]], only defined inside  [minValue, maxValue]
+    * @return A PartialFunction[Double, Color], only defined inside  [minValue, maxValue]
     *         If a function that is defined for all doubles is desired, use [[singleGradientComplete]] */
   def singleGradient(
     minValue: Double,
@@ -99,7 +99,7 @@ object GradientUtils {
 
   /** Create a gradient between two colors on a double range that is defined outside of
     * the range.
-    * @return a [[Double => Color]] that returns an interpolated color for doubles inside
+    * @return a Double => Color that returns an interpolated color for doubles inside
     *        the range, or the respective end point for doubles outside the range. */
   def singleGradientComplete(
     minValue: Double,


### PR DESCRIPTION
Remove incorrect links in Scaladoc and add doc generation task to the Travis build to ensure that the documentation on master builds.