### PR TITLE
Add default args for Plot#xbounds and Plot#ybounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Changes since last release]
 
+### Added
+- Ability to partially update the bounds of a plot using `xbounds` and `ybounds`. Providing only `lower` or `upper` to these functions is now possible.
 
 ## [0.4.0] - 2018-07-18
 ### Added

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Plot.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Plot.scala
@@ -77,7 +77,8 @@ final case class Plot(
     * @param lower the new minimum x
     * @param upper the new maximum x
     */
-  def xbounds(lower: Double, upper: Double): Plot = xbounds(Bounds(lower, upper))
+  def xbounds(lower: Double = xbounds.min, upper: Double = xbounds.max): Plot =
+    xbounds(Bounds(lower, upper))
 
   /** Create a copy of this plot with updated y bounds
     * @param newBounds the new bounds.
@@ -88,7 +89,8 @@ final case class Plot(
     * @param lower the new minimum y
     * @param upper the new maximum y
     */
-  def ybounds(lower: Double, upper: Double): Plot = ybounds(Bounds(lower, upper))
+  def ybounds(lower: Double = ybounds.min, upper: Double = ybounds.max): Plot =
+    ybounds(Bounds(lower, upper))
 
   private[plot] def updateBounds(xb: Bounds, yb: Bounds): Plot = copy(xbounds = xb, ybounds = yb)
 

--- a/shared/src/test/scala/com/cibo/evilplot/plot/PlotSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/plot/PlotSpec.scala
@@ -96,4 +96,24 @@ class PlotSpec extends FunSpec with Matchers {
     renderer.plotExtentOpt.get shouldBe extent
   }
 
+  it("xbounds/ybounds without parens should access bounds") {
+    val plot = newPlot(xbounds = Bounds(0, 2), ybounds = Bounds(0, 5))
+
+    plot.xbounds shouldBe Bounds(0, 2)
+    plot.ybounds shouldBe Bounds(0, 5)
+  }
+
+  it("partial xbounds/ybounds update should work") {
+    val plot = newPlot(xbounds = Bounds(0, 2), ybounds = Bounds(0, 5))
+    val updatedX = plot.xbounds(lower = -5)
+    updatedX.xbounds shouldBe Bounds(-5, 2)
+    val doubleUpdatedX = updatedX.xbounds(upper = 5)
+    doubleUpdatedX.xbounds shouldBe Bounds(-5, 5)
+
+    val updatedY = plot.ybounds(lower = -7)
+    updatedY.ybounds shouldBe Bounds(-7, 5)
+    val doubleUpdatedY = updatedY.ybounds(upper = 7)
+    doubleUpdatedY.ybounds shouldBe Bounds(-7, 7)
+  }
+
 }


### PR DESCRIPTION
This allows conveniently just setting the lower bounds of a plot while retaining the current upper bounds. e.g.

plot.ybounds(lower = 0) keeps the current y upper bound but sets the y lower bound to 0.