### PR TITLE
Added normalizing option to Histogram

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/plot/Histogram.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Histogram.scala
@@ -40,7 +40,7 @@ object Histogram {
   val defaultBinCount: Int = 20
 
   // Create binCount bins from the given data and xbounds.
-  private def createBins(values: Seq[Double], xbounds: Bounds, binCount: Int, normalize: Boolean = false): Seq[Point] = {
+  private def createBins(values: Seq[Double], xbounds: Bounds, binCount: Int, normalize: Boolean): Seq[Point] = {
     val binWidth = xbounds.range / binCount
     val grouped = values.groupBy { value =>
       math.min(((value - xbounds.min) / binWidth).toInt, binCount - 1)

--- a/shared/src/test/scala/com/cibo/evilplot/plot/HistogramSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/plot/HistogramSpec.scala
@@ -57,5 +57,6 @@ class HistogramSpec extends FunSpec with Matchers {
       val emptyPlot = Histogram(Seq.empty)
       emptyPlot.render(extent).extent shouldBe extent
     }
+
   }
 }


### PR DESCRIPTION
Adds an option to normalize the histogram. This can allow multiple `Histogram`s to be overlayed and compared.

For example:
<img width="775" alt="image" src="https://user-images.githubusercontent.com/227339/43023707-6d21a51a-8c31-11e8-9799-12827672e79b.png">
