### PR TITLE
Coloring for PathRenderer and Heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Bug resulting in misalignment of axes and gridlines in some faceted plots.
 
+
 ## [0.4.0] - 2018-07-18
 ### Added
 - `BoxRenderer.colorBy` box renderer for custom coloring on box plots.

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -318,6 +318,7 @@ object DemoPlots {
       .standard()
       .ybounds(0, 0.2)
       .rightLegend()
+
       .render(plotAreaSize)
   }
 

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -318,7 +318,6 @@ object DemoPlots {
       .standard()
       .ybounds(0, 0.2)
       .rightLegend()
-
       .render(plotAreaSize)
   }
 

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -322,8 +322,8 @@ object DemoPlots {
       Seq(5, 6, 7, 8),
       Seq(9, 8, 7, 6)
     )
-
-    Heatmap(data).title("Heatmap Demo").xAxis().yAxis().rightLegend().render(plotAreaSize)
+    val coloring = ContinuousColoring.gradient3(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson, HTMLNamedColors.dodgerBlue)
+    Heatmap(data, Some(coloring)).title("Heatmap Demo").xAxis().yAxis().rightLegend().render(plotAreaSize)
   }
 
 

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -306,12 +306,18 @@ object DemoPlots {
         ))
       .map(Point.tupled)
 
-    val pathRenderer = Some(PathRenderer.depthColor(Seq(0, 1, 2, 1, 2, 0),
-      Some(ContinuousColoring.gradient(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson))))
+    val pathRenderer = Some(
+      PathRenderer.depthColor(
+        Seq(0, 1, 2, 1, 2, 0),
+        Some(ContinuousColoring.gradient(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson))))
 
     LinePlot(
-      data, pathRenderer = pathRenderer
-    ).ybounds(0, .12).standard().ybounds(0, 0.2).rightLegend()
+      data,
+      pathRenderer = pathRenderer
+    ).ybounds(0, .12)
+      .standard()
+      .ybounds(0, 0.2)
+      .rightLegend()
       .render(plotAreaSize)
   }
 

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -302,16 +302,16 @@ object DemoPlots {
       .map(_.toDouble)
       .zip(
         Seq(
-          0.0, 0.1, 0.0, 0.1, 0.0, 0.1
+          0.0, 0.1, 0.2, 0.1, 0.0, 0.1
         ))
       .map(Point.tupled)
 
-    val pathRenderer = Some(PathRenderer.depthColor(Seq(1,2,3,4,5), Some(ContinuousColoring.gradient(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson))))
-    println(pathRenderer)
+    val pathRenderer = Some(PathRenderer.depthColor(Seq(0, 1, 2, 1, 2, 0),
+      Some(ContinuousColoring.gradient(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson))))
 
     LinePlot(
-      data
-    ).ybounds(0, .12).standard()
+      data, pathRenderer = pathRenderer
+    ).ybounds(0, .12).standard().ybounds(0, 0.2).rightLegend()
       .render(plotAreaSize)
   }
 

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -306,13 +306,12 @@ object DemoPlots {
         ))
       .map(Point.tupled)
 
+    val pathRenderer = Some(PathRenderer.depthColor(Seq(1,2,3,4,5), Some(ContinuousColoring.gradient(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson))))
+    println(pathRenderer)
+
     LinePlot(
       data
-    ).ybounds(0, .12)
-      .yAxis()
-      .xGrid()
-      .yGrid()
-      .frame()
+    ).ybounds(0, .12).standard()
       .render(plotAreaSize)
   }
 
@@ -322,8 +321,16 @@ object DemoPlots {
       Seq(5, 6, 7, 8),
       Seq(9, 8, 7, 6)
     )
-    val coloring = ContinuousColoring.gradient3(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson, HTMLNamedColors.dodgerBlue)
-    Heatmap(data, Some(coloring)).title("Heatmap Demo").xAxis().yAxis().rightLegend().render(plotAreaSize)
+    val coloring = ContinuousColoring.gradient3(
+      HTMLNamedColors.dodgerBlue,
+      HTMLNamedColors.crimson,
+      HTMLNamedColors.dodgerBlue)
+    Heatmap(data, Some(coloring))
+      .title("Heatmap Demo")
+      .xAxis()
+      .yAxis()
+      .rightLegend()
+      .render(plotAreaSize)
   }
 
 

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
@@ -109,6 +109,7 @@ object Heatmap {
 
   def apply(data: Seq[Seq[Double]],
             coloring: Option[Coloring[Double]])(implicit theme: Theme): Plot = {
+
     val flattenedData = data.flatten
     val minValue = flattenedData.reduceOption[Double](math.min).getOrElse(0.0)
     val maxValue = flattenedData.reduceOption[Double](math.max).getOrElse(0.0)

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
@@ -106,8 +106,9 @@ object Heatmap {
     * @param data The heatmap data.
     * @param coloring The coloring to use.
     */
-  def apply(data: Seq[Seq[Double]], coloring: Option[Coloring[Double]])(
-    implicit theme: Theme): Plot = {
+
+  def apply(data: Seq[Seq[Double]],
+            coloring: Option[Coloring[Double]])(implicit theme: Theme): Plot = {
     val flattenedData = data.flatten
     val minValue = flattenedData.reduceOption[Double](math.min).getOrElse(0.0)
     val maxValue = flattenedData.reduceOption[Double](math.max).getOrElse(0.0)

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
@@ -102,6 +102,10 @@ object Heatmap {
     apply(data, colorBar)
   }
 
+  /** Create a heatmap using a continuous coloring.
+    * @param data The heatmap data.
+    * @param coloring The coloring to use.
+    */
   def apply(data: Seq[Seq[Double]], coloring: Option[Coloring[Double]])(
     implicit theme: Theme): Plot = {
     val flattenedData = data.flatten

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
@@ -30,7 +30,7 @@
 
 package com.cibo.evilplot.plot
 
-import com.cibo.evilplot.colors.{Color, ScaledColorBar}
+import com.cibo.evilplot.colors.{Color, Coloring, ScaledColorBar}
 import com.cibo.evilplot.geometry.{Drawable, Extent, Rect}
 import com.cibo.evilplot.numeric.Bounds
 import com.cibo.evilplot.plot.aesthetics.Theme
@@ -100,5 +100,17 @@ object Heatmap {
     val maxValue = flattenedData.reduceOption[Double](math.max).getOrElse(0.0)
     val colorBar = ScaledColorBar(colorStream.take(colorCount), minValue, maxValue)
     apply(data, colorBar)
+  }
+
+  def apply(data: Seq[Seq[Double]],
+            coloring: Option[Coloring[Double]])(implicit theme: Theme): Plot = {
+    val flattenedData = data.flatten
+    val minValue = flattenedData.reduceOption[Double](math.min).getOrElse(0.0)
+    val maxValue = flattenedData.reduceOption[Double](math.max).getOrElse(0.0)
+    val useColoring = coloring.getOrElse(theme.colors.continuousColoring)
+    val colorFunc = useColoring(flattenedData)
+    val colorBar = ScaledColorBar(flattenedData.map(point => colorFunc.apply(point)), minValue, maxValue)
+    apply(data, colorBar)
+
   }
 }

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
@@ -102,14 +102,15 @@ object Heatmap {
     apply(data, colorBar)
   }
 
-  def apply(data: Seq[Seq[Double]],
-            coloring: Option[Coloring[Double]])(implicit theme: Theme): Plot = {
+  def apply(data: Seq[Seq[Double]], coloring: Option[Coloring[Double]])(
+    implicit theme: Theme): Plot = {
     val flattenedData = data.flatten
     val minValue = flattenedData.reduceOption[Double](math.min).getOrElse(0.0)
     val maxValue = flattenedData.reduceOption[Double](math.max).getOrElse(0.0)
     val useColoring = coloring.getOrElse(theme.colors.continuousColoring)
     val colorFunc = useColoring(flattenedData)
-    val colorBar = ScaledColorBar(flattenedData.map(point => colorFunc.apply(point)), minValue, maxValue)
+    val colorBar =
+      ScaledColorBar(flattenedData.map(point => colorFunc.apply(point)), minValue, maxValue)
     apply(data, colorBar)
 
   }

--- a/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
@@ -124,6 +124,13 @@ object PathRenderer {
       lineStyle
     )
 
+  /**
+    * Render line with colors based on a third, continuous variable.
+    * @param depths The depths for each line segment.
+    * @param coloring The coloring to use.
+    * @param strokeWidth The thickness of the line.
+    * @param lineStyle The style of the line
+    */
   def depthColor(
     depths: Seq[Double],
     coloring: Option[Coloring[Double]] = None,
@@ -133,20 +140,15 @@ object PathRenderer {
     private val colorFunc = useColoring(depths)
     private val useLineStyle: LineStyle = lineStyle.getOrElse(theme.elements.lineDashStyle)
     def render(plot: Plot, extent: Extent, path: Seq[Point]): Drawable = {
-      require(Clipping.clipPath(path, extent).length == depths.length)
-      println(Clipping.clipPath(path, extent).length)
       Clipping
         .clipPath(path, extent)
-        .zip(depths)
-        .map(
-          segment =>
-            segment._1.sliding(2,1).map(section =>
-            LineDash(
-              StrokeStyle(
-                Path(section, strokeWidth.getOrElse(theme.elements.strokeWidth)),
-                colorFunc(segment._2)),
-              useLineStyle)
-            ).toSeq).head.group
+        .flatMap(p => p.sliding(2,1).toSeq.zipWithIndex.map { case (section, index) =>
+          LineDash(
+            StrokeStyle(
+              Path(section, strokeWidth.getOrElse(theme.elements.strokeWidth)),
+              colorFunc(depths(index))),
+            useLineStyle)
+        }).group
     }
 
     override def legendContext: LegendContext =

--- a/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
@@ -132,6 +132,7 @@ object PathRenderer {
     * @param coloring The coloring to use.
     * @param strokeWidth The width of the path.
     * @param lineStyle The style of the path (dashed, solid, etc).
+
     */
   def depthColor(
     depths: Seq[Double],
@@ -154,6 +155,7 @@ object PathRenderer {
                 useLineStyle)
         })
         .group
+
 
     }
 

--- a/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
@@ -33,7 +33,6 @@ package com.cibo.evilplot.plot.renderers
 import com.cibo.evilplot.colors.{Color, Coloring}
 import com.cibo.evilplot.geometry.{
   Clipping,
-  Disc,
   Drawable,
   EmptyDrawable,
   Extent,
@@ -60,6 +59,7 @@ object PathRenderer {
     * @param strokeWidth The width of the path.
     * @param color Point color.
     * @param label A label for this path (for legends).
+    * @param lineStyle The style of the path (dashed, solid, etc).
     */
   def default(
     strokeWidth: Option[Double] = None,
@@ -108,6 +108,7 @@ object PathRenderer {
     * @param name The name of this path.
     * @param color The color of this path.
     * @param strokeWidth The width of the path.
+    * @param lineStyle The style of the path (dashed, solid, etc).
     */
   def named(
     name: String,
@@ -128,8 +129,8 @@ object PathRenderer {
     * Render line with colors based on a third, continuous variable.
     * @param depths The depths for each line segment.
     * @param coloring The coloring to use.
-    * @param strokeWidth The thickness of the line.
-    * @param lineStyle The style of the line
+    * @param strokeWidth The width of the path.
+    * @param lineStyle The style of the path (dashed, solid, etc).
     */
   def depthColor(
     depths: Seq[Double],
@@ -142,13 +143,16 @@ object PathRenderer {
     def render(plot: Plot, extent: Extent, path: Seq[Point]): Drawable = {
       Clipping
         .clipPath(path, extent)
-        .flatMap(p => p.sliding(2,1).toSeq.zipWithIndex.map { case (section, index) =>
-          LineDash(
-            StrokeStyle(
-              Path(section, strokeWidth.getOrElse(theme.elements.strokeWidth)),
-              colorFunc(depths(index))),
-            useLineStyle)
-        }).group
+        .flatMap(p =>
+          p.sliding(2, 1).toSeq.zipWithIndex.map {
+            case (section, index) =>
+              LineDash(
+                StrokeStyle(
+                  Path(section, strokeWidth.getOrElse(theme.elements.strokeWidth)),
+                  colorFunc(depths(index))),
+                useLineStyle)
+        })
+        .group
     }
 
     override def legendContext: LegendContext =
@@ -165,6 +169,7 @@ object PathRenderer {
     * @param strokeWidth the stroke width
     * @param color the color of the path
     * @param label the label for the legend
+    * @param lineStyle The style of the path (dashed, solid, etc).
     */
   def closed(
     strokeWidth: Option[Double] = None,

--- a/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
@@ -33,6 +33,7 @@ package com.cibo.evilplot.plot.renderers
 import com.cibo.evilplot.colors.{Color, Coloring}
 import com.cibo.evilplot.geometry.{
   Clipping,
+  Disc,
   Drawable,
   EmptyDrawable,
   Extent,
@@ -153,6 +154,7 @@ object PathRenderer {
                 useLineStyle)
         })
         .group
+
     }
 
     override def legendContext: LegendContext =

--- a/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/renderers/PathRenderer.scala
@@ -33,7 +33,6 @@ package com.cibo.evilplot.plot.renderers
 import com.cibo.evilplot.colors.{Color, Coloring}
 import com.cibo.evilplot.geometry.{
   Clipping,
-  Disc,
   Drawable,
   EmptyDrawable,
   Extent,
@@ -132,7 +131,6 @@ object PathRenderer {
     * @param coloring The coloring to use.
     * @param strokeWidth The width of the path.
     * @param lineStyle The style of the path (dashed, solid, etc).
-
     */
   def depthColor(
     depths: Seq[Double],
@@ -155,8 +153,6 @@ object PathRenderer {
                 useLineStyle)
         })
         .group
-
-
     }
 
     override def legendContext: LegendContext =


### PR DESCRIPTION
Adds:
- `apply` method to heatmap for use with continuous colorings
- `depthPathRenderer` for rendering paths with a thirds continuous variable

<img width="1009" alt="screen shot 2018-07-24 at 2 20 56 pm" src="https://user-images.githubusercontent.com/13050409/43158172-06b79e32-8f4d-11e8-8d26-39491058c8fa.png">
<img width="1021" alt="screen shot 2018-07-24 at 2 21 59 pm" src="https://user-images.githubusercontent.com/13050409/43158208-1c5104b8-8f4d-11e8-9808-ea847a2cb952.png">
