### PR TITLE
Add support for discrete axis tick alignment.

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -136,12 +136,14 @@ object DemoPlots {
         Seq("foo", "bar", "baz"),
         Seq(1d, 2, 10),
         Position.Bottom,
-        updatePlotBounds = false)
+        updatePlotBounds = false,
+        align = 0)
       .discreteAxis(
         filler,
         filler.indices.map(_.toDouble),
         Position.Right,
-        updatePlotBounds = false)
+        updatePlotBounds = false,
+        align = 0.5)
       .continuousAxis(
         plot => plot.xbounds,
         Position.Top,


### PR DESCRIPTION
Quick support for basic discrete axis tick alignment. Discrete axes still make assumptions about the size of bands, but this should cover the use cases we've seen so far: mainly, labeling non-banded data with a discrete axis.

align 0:
<img width="420" alt="screen shot 2018-07-26 at 11 16 21 am" src="https://user-images.githubusercontent.com/1902485/43271850-a43c0d08-90c6-11e8-9705-0cc10e287c52.png">

align 0.5:
<img width="413" alt="screen shot 2018-07-26 at 11 16 44 am" src="https://user-images.githubusercontent.com/1902485/43271875-b10a7c2c-90c6-11e8-8eea-565ad88843c4.png">

align 1:
<img width="407" alt="screen shot 2018-07-26 at 11 17 09 am" src="https://user-images.githubusercontent.com/1902485/43271893-b993378a-90c6-11e8-9317-8632320ae207.png">
