### PR TITLE
add coloring apply to heatmap

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -324,8 +324,8 @@ object DemoPlots {
       Seq(5, 6, 7, 8),
       Seq(9, 8, 7, 6)
     )
-
-    Heatmap(data).title("Heatmap Demo").xAxis().yAxis().rightLegend().render(plotAreaSize)
+    val coloring = ContinuousColoring.gradient3(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson, HTMLNamedColors.dodgerBlue)
+    Heatmap(data, Some(coloring)).title("Heatmap Demo").xAxis().yAxis().rightLegend().render(plotAreaSize)
   }
 
 

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Heatmap.scala
@@ -30,7 +30,7 @@
 
 package com.cibo.evilplot.plot
 
-import com.cibo.evilplot.colors.{Color, ScaledColorBar}
+import com.cibo.evilplot.colors.{Color, Coloring, ScaledColorBar}
 import com.cibo.evilplot.geometry.{Drawable, Extent, Rect}
 import com.cibo.evilplot.numeric.Bounds
 import com.cibo.evilplot.plot.aesthetics.Theme
@@ -100,5 +100,17 @@ object Heatmap {
     val maxValue = flattenedData.reduceOption[Double](math.max).getOrElse(0.0)
     val colorBar = ScaledColorBar(colorStream.take(colorCount), minValue, maxValue)
     apply(data, colorBar)
+  }
+
+  def apply(data: Seq[Seq[Double]],
+            coloring: Option[Coloring[Double]])(implicit theme: Theme): Plot = {
+    val flattenedData = data.flatten
+    val minValue = flattenedData.reduceOption[Double](math.min).getOrElse(0.0)
+    val maxValue = flattenedData.reduceOption[Double](math.max).getOrElse(0.0)
+    val useColoring = coloring.getOrElse(theme.colors.continuousColoring)
+    val colorFunc = useColoring(flattenedData)
+    val colorBar = ScaledColorBar(flattenedData.map(point => colorFunc.apply(point)), minValue, maxValue)
+    apply(data, colorBar)
+
   }
 }


### PR DESCRIPTION
Adds `apply` method to heatmap for use with continuous colorings
<img width="1009" alt="screen shot 2018-07-24 at 2 20 56 pm" src="https://user-images.githubusercontent.com/13050409/43608758-f8e1fc56-966f-11e8-83d0-1b4201b48c43.png">
