### PR TITLE
path renderer with coloring

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -304,17 +304,22 @@ object DemoPlots {
       .map(_.toDouble)
       .zip(
         Seq(
-          0.0, 0.1, 0.0, 0.1, 0.0, 0.1
+          0.0, 0.1, 0.2, 0.1, 0.0, 0.1
         ))
       .map(Point.tupled)
 
+    val pathRenderer = Some(
+      PathRenderer.depthColor(
+        Seq(0, 1, 2, 1, 2, 0),
+        Some(ContinuousColoring.gradient(HTMLNamedColors.dodgerBlue, HTMLNamedColors.crimson))))
+
     LinePlot(
-      data
+      data,
+      pathRenderer = pathRenderer
     ).ybounds(0, .12)
-      .yAxis()
-      .xGrid()
-      .yGrid()
-      .frame()
+      .standard()
+      .ybounds(0, 0.2)
+      .rightLegend()
       .render(plotAreaSize)
   }
 
@@ -327,7 +332,6 @@ object DemoPlots {
 
     Heatmap(data).title("Heatmap Demo").xAxis().yAxis().rightLegend().render(plotAreaSize)
   }
-
 
   lazy val facetedPlot: Drawable = {
     val years = 2007 to 2013


### PR DESCRIPTION
Adds a `depthColoring` function similar to the point renderer version to create multicolored line plots.
<img width="1021" alt="screen shot 2018-07-24 at 2 21 59 pm" src="https://user-images.githubusercontent.com/13050409/43609142-31559fa6-9671-11e8-9f9c-a15046e21e57.png">
