### PR TITLE
Add withMeanLine method to BoxRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Changes since last release]
 ### Added
 - Support for clustered box plots.
+- Option to display the data's mean as a dashed line on box plots.
 ### Fixed
 - Bug in the spacing and sizing of bars in clustered bar charts.
 

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -234,7 +234,7 @@ object DemoPlots {
   lazy val boxPlot: Drawable = {
     val data = Seq.fill(10)(Seq.fill(Random.nextInt(30))(Random.nextDouble()))
     val series = Seq.fill(10)(Random.nextInt(2))
-    BoxPlot(data, boxRenderer = Some(BoxRenderer.colorBy(series)))
+    BoxPlot(data, boxRenderer = Some(BoxRenderer.colorBy(series).withMeanLine()))
       .standard(xLabels = (1 to 10).map(_.toString))
       .rightLegend()
       .render(plotAreaSize)

--- a/shared/src/main/scala/com/cibo/evilplot/plot/renderers/BoxRenderer.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/renderers/BoxRenderer.scala
@@ -30,7 +30,7 @@
 
 package com.cibo.evilplot.plot.renderers
 
-import com.cibo.evilplot.colors.{CategoricalColoring, Color}
+import com.cibo.evilplot.colors.{CategoricalColoring, Color, HTMLNamedColors}
 import com.cibo.evilplot.geometry.{
   Align,
   BorderRect,
@@ -38,17 +38,42 @@ import com.cibo.evilplot.geometry.{
   Extent,
   Line,
   LineDash,
+  LineStyle,
   Rect,
-  StrokeStyle
+  StrokeStyle,
+  Translate
 }
 import com.cibo.evilplot.numeric.BoxPlotSummaryStatistics
 import com.cibo.evilplot.plot.aesthetics.Theme
 import com.cibo.evilplot.plot.renderers.BoxRenderer.BoxRendererContext
 import com.cibo.evilplot.plot.{LegendContext, Plot}
 
-trait BoxRenderer extends PlotElementRenderer[BoxRendererContext] {
+trait BoxRenderer extends PlotElementRenderer[BoxRendererContext] { br =>
   def render(plot: Plot, extent: Extent, summary: BoxRendererContext): Drawable
   def legendContext: LegendContext = LegendContext.empty
+
+  /** Construct a new [[BoxRenderer]] whose `render` method wraps [[render]],
+    * adding a dashed line at the data's mean.
+    *
+    * @param color  color of line at mean
+    * @return       a new [[BoxRenderer]] that adds a line at the mean
+    * */
+  def withMeanLine(
+    color: Color = HTMLNamedColors.darkRed
+   )(implicit theme: Theme): BoxRenderer = new BoxRenderer {
+    def render(plot: Plot, extent: Extent, summary: BoxRendererContext): Drawable = {
+      val box = br.render(plot, extent, summary)
+
+      val data = summary.summaryStatistics.allPoints
+      val avg = data.sum / data.length
+
+      val dashedLine = Line(extent.width, theme.elements.strokeWidth).dashed(LineStyle.Dashed)
+      val y = plot.ytransform(plot, extent)(avg) - theme.elements.strokeWidth / 2d
+      val meanLine = StrokeStyle(Translate(dashedLine, y = y), color)
+
+      box behind meanLine
+    }
+  }
 }
 
 object BoxRenderer {


### PR DESCRIPTION
Makes it possible to add a dashed line at the distribution's mean on any box plot, e.g.:

<img width="1024" alt="screen shot 2018-09-06 at 2 14 16 pm" src="https://user-images.githubusercontent.com/14116434/45176825-2caa9400-b1df-11e8-8f70-02ed68c0d332.png">
