### PR TITLE
extract rgba values from colors

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/colors/Color.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/Color.scala
@@ -34,10 +34,12 @@ import io.circe.{Decoder, Encoder}
 
 sealed trait Color {
   val repr: String
+  def rgba: (Int,Int,Int,Double)
 }
 
 case object Clear extends Color {
   val repr = "hsla(0, 0%, 0%, 0)"
+  def rgba:(Int,Int,Int,Double) = (0,0,0,0.0)
 }
 
 case class HSLA(hue: Int, saturation: Int, lightness: Int, opacity: Double) extends Color {
@@ -73,6 +75,15 @@ case class HSLA(hue: Int, saturation: Int, lightness: Int, opacity: Double) exte
   }
 
   val repr = s"hsla($hue, $saturation%, $lightness%, $opacity)"
+  def rgba:(Int,Int,Int,Double) = {
+    val allDouble = ColorUtils.hslaToRgba(this)
+    (
+      (allDouble._1 * 255.0).toInt,
+      (allDouble._2 * 255.0).toInt,
+      (allDouble._3 * 255.0).toInt,
+      allDouble._4
+    )
+  }
 }
 
 object RGBA {

--- a/shared/src/test/scala/com/cibo/evilplot/colors/ColorsSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/colors/ColorsSpec.scala
@@ -48,6 +48,20 @@ class ColorsSpec extends FunSpec with TypeCheckedTripleEquals {
     }
   }
 
+  describe("toRGBA cfunctions") {
+    it("should make clear transparent") {
+      val baseColor = Clear
+      baseColor.rgba._4 shouldBe 0.0
+    }
+    it("should recover a rgba color") {
+      val baseColor = RGBA(77,255,22,1.0)
+      println(baseColor)
+      println(ColorUtils.hslaToRgba(baseColor))
+
+      baseColor.rgba shouldBe (75, 255,20,1.0)
+    }
+  }
+
   describe("HSLA functions") {
     it("should darken and lighten") {
       val baseColor = HSLA(0, 0, 0, 0)


### PR DESCRIPTION
Evilplot has a gradient functionality useful outside of plots, which works just fine in situations where the output of.repr is sufficient to represent a color. Unfortunately, there are cases where it isn't, like building bitmaps.

I face two possibilities: One is to forget about Evilplot's coloring library across the board, and build another (with blackjack...), which would probably take too much time if done right, but would target replacing this part of Evilplot's infra. The other is just to expose the rgba conversion, which evilplot already has. 

This PR would do the second alternative. Note that, since Hues are represented as ints, and rounded immediately, roundtrip conversions get pretty lossy. Given that, in practice, browsers output to rgb, and only a small percentage of valid RGB colors line up with a 'whole' int Hue, this is probably best fixed by switching hues to Doubles, but that's probably a different PR.