### PR TITLE
Switch to plain Double, guarantee bounds are included

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/plot/components/PlotLine.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/components/PlotLine.scala
@@ -157,12 +157,12 @@ object FunctionPlotLine {
       case 0 => Vector.empty[Point]
       case 1 => Vector(pointAt(xbounds.min))
       case _ =>
-        val bdMin = BigDecimal(xbounds.min)
-        val bdMax = BigDecimal(xbounds.max)
+        val bdMin = xbounds.min
+        val bdMax = xbounds.max
         val step = (bdMax - bdMin) / (numPoints - 1)
-        Vector.tabulate(numPoints) { i =>
-          pointAt((bdMin + step * i).toDouble)
-        }
+        Vector.tabulate(numPoints - 2) { i =>
+          pointAt(bdMin + step * (i + 1))
+        }.+:(pointAt(bdMin)).:+(pointAt(bdMax)) // guarantee bounds are included
     }
   }
 }

--- a/shared/src/test/scala/com/cibo/evilplot/plot/components/FunctionPlotLineSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/plot/components/FunctionPlotLineSpec.scala
@@ -31,9 +31,21 @@
 package com.cibo.evilplot.plot.components
 
 import com.cibo.evilplot.numeric.{Bounds, Point}
+import org.scalactic.{Equality, TolerantNumerics}
 import org.scalatest.{FunSpec, Matchers}
 
 class FunctionPlotLineSpec extends FunSpec with Matchers {
+
+  implicit val doubleEquality: Equality[Double] =
+    TolerantNumerics.tolerantDoubleEquality(1e-10)
+
+  implicit object VectorDoubleEquivalence extends Equality[Vector[Double]] {
+    def areEqual(a: Vector[Double], b: Any): Boolean = b match {
+      case bx: Vector[_] => a.corresponds(bx)((i, j) => doubleEquality.areEqual(i, j))
+      case _          => false
+    }
+  }
+
   describe("plottablePoints") {
     val bounds = Bounds(0, 1)
 
@@ -100,7 +112,7 @@ class FunctionPlotLineSpec extends FunSpec with Matchers {
       val points = FunctionPlotLine.pointsForFunction(x => x, Bounds(0, 1), 11)
 
       points.length shouldBe 11
-      points.map(_.x) shouldBe Seq(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+      points.map(_.x) shouldEqual Vector(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
     }
 
     it("should still return the max bound point for large sequences of small x steps") {


### PR DESCRIPTION
Previous logic was using BigDecimal to guarantee inclusion of bounds. This method prepends and appends the bounds and "fills" the missing points in between.