### PR TITLE
add default theme to the Theme companion object

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/plot/aesthetics/Theme.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/aesthetics/Theme.scala
@@ -44,3 +44,8 @@ final case class Theme(
   colors: Colors,
   elements: Elements
 )
+
+object Theme{
+  /**An automatic default theme at a low priority precedence*/
+  implicit val defaultTheme:Theme = com.cibo.evilplot.plot.aesthetics.DefaultTheme.defaultTheme
+}


### PR DESCRIPTION
Implicits have a “very” complicated priority lookup scheme.  For the most part I try to use them at either a VeryLow priority (within it’s own object) or at a VeryHigh  precedence (local scope definition). 

Including the default implicit in the companion object is an idiomatic and ideal use case of a default configuration type like this.  If a user wants a specific theme they can add it; otherwise they don't even have to know about themes.  Furthermore, the tutorials and getting up to speed examples can be much more approachable by removing the friction from these unrelated details, but still make them configurable if someone desires this tangential feature.