### PR TITLE
fix histogram by using dataBounds instead of axis bounds

### DIFF
--- a/jvm/src/test/scala/com/cibo/evilplot/HistogramTest.scala
+++ b/jvm/src/test/scala/com/cibo/evilplot/HistogramTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, CiBO Technologies, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.cibo.evilplot
+
+import com.cibo.evilplot._
+import com.cibo.evilplot.geometry._
+import com.cibo.evilplot.plot._
+import com.cibo.evilplot.plot.aesthetics.DefaultTheme._
+import com.cibo.evilplot.numeric.Point
+
+object HistogramTest{
+  def main(args:Array[String]):Unit = {
+
+    def test(N:Int, useStandard:Boolean):Unit = {
+
+      val rand = new scala.util.Random(999)
+      def noise:Double = rand.nextGaussian
+
+      val data = Vector.fill(N){ noise }
+
+      val hist = Histogram(data)
+
+      val (plot,classifier) = 
+        if(useStandard) (hist.standard(), "standard")
+        else            (hist,            "none"    )
+      val file = new java.io.File(s"hist-$N-$classifier.png")
+
+      plot.render().write(file)
+
+    }
+    //--make a bunch of plots
+    for(i <- 1 to 5; useStandard <-  Seq(false, true) ) test(math.pow(10,i).toInt,useStandard)
+  }
+}

--- a/shared/src/main/scala/com/cibo/evilplot/plot/Histogram.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/plot/Histogram.scala
@@ -117,11 +117,13 @@ object Histogram {
         // Scaling the bars would show the correct histogram as long as no axis is displayed.  However, if
         // an axis is display, we would end up showing the wrong values. Thus, we clip if the y boundary is
         // fixed, otherwise we scale to make it look pretty.
-        val points = binningFunction(data, plot.xbounds, binCount)
+        
+        val dataBounds = Bounds.get(data) getOrElse plot.xbounds
+        val points = binningFunction(data, dataBounds, binCount)
         val maxY = points.maxBy(_.y).y * (1.0 + boundBuffer)
         val yscale = if (plot.yfixed) 1.0 else math.min(1.0, plot.ybounds.max / maxY)
 
-        val binWidth = plot.xbounds.range / binCount
+        val binWidth = dataBounds.range / binCount
         val yintercept = ytransformer(0)
         points.map { point =>
           val x = xtransformer(point.x) + spacing / 2.0


### PR DESCRIPTION
This deceptively simple change should fix this histogram bin locations and upper bound clipping.

https://github.com/cibotech/sprint-planning/issues/3618

https://github.com/cibotech/sprint-planning/issues/3621

There is a png generator to generate a bunch of variants:  Here are some

*Before*:
![hist-1000-standard](https://user-images.githubusercontent.com/9483964/46379827-b2e2ba80-c665-11e8-952b-2df49671fe82.png)

*After*:
![hist-1000-standard](https://user-images.githubusercontent.com/9483964/46379835-baa25f00-c665-11e8-9f1a-744417edcfbf.png)
