### PR TITLE
Fix colorbar failing when data is out of range

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/colors/ColorBar.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/ColorBar.scala
@@ -57,7 +57,7 @@ case class ScaledColorBar(colorSeq: Seq[Color], zMin: Double, zMax: Double) exte
   def getColor(z: Double): Color = getColor(colorIndex(z))
 
   def colorIndex(z: Double): Int =
-    math.min(math.round(math.floor((z - zMin) / zWidth)).toInt, nColors - 1)
+    math.min(math.round(math.floor(math.max(z - zMin, 0.0) / zWidth)).toInt, nColors - 1)
   def colorValue(i: Int): Double = i * zWidth + zMin
 }
 

--- a/shared/src/test/scala/com/cibo/evilplot/colors/ColorsSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/colors/ColorsSpec.scala
@@ -46,6 +46,19 @@ class ColorsSpec extends FunSpec with TypeCheckedTripleEquals {
       colorsFromData.head should !==(colorsFromData(1))
       colorsFromData.head should !==(colorsFromData(3))
     }
+
+    it("should clip data to the colorbar's range") {
+      val z: Seq[Double] = Seq(2012, 2013, 2012, 2011, 2014, 2010)
+
+      val colorBar = ScaledColorBar(Color.getGradientSeq(3), 2011, 2013)
+      val colorsFromData = z.map(colorBar.getColor)
+
+      colorsFromData.head should ===(colorsFromData(2))
+      colorsFromData.head should !==(colorsFromData(1))
+      colorsFromData.head should !==(colorsFromData(3))
+      colorsFromData(3) should ===(colorsFromData(5))
+      colorsFromData(1) should ===(colorsFromData(4))
+    }
   }
 
   describe("toRGBA cfunctions") {


### PR DESCRIPTION
Fix ScaledColorBar.colorIndex's handling of input data and add appropriate test conditions

This addresses an IndexOutOfBoundsException when inputs lower than the colorbar's minimum value are assigned an index. Inputs that are higher than the colorbar's maximum value were handled correctly.

Existing unit tests were updated to test these conditions.