### PR TITLE
Gracefully handle NaN in gradient functions

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
@@ -67,7 +67,7 @@ object GradientUtils {
         {
           if (d < min) colors.head
           else if (d > max) colors.last
-          else if (d.isNaN) RGBA(0,0,0,0)
+          else if (d.isNaN) Clear
           else complete(d)
         }
     }
@@ -98,7 +98,7 @@ object GradientUtils {
         val b = interpolate(inverse(b1), inverse(b2), interpolationCoefficient)
         val a = interpolate(a1, a2, interpolationCoefficient)
         RGBA((255 * forward(r)).toInt, (255 * forward(g)).toInt, (255 * forward(b)).toInt, a)
-      case noData if noData.isNaN => RGBA(0,0,0,0)
+      case noData if noData.isNaN => Clear
     }
   }
 

--- a/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/GradientUtils.scala
@@ -67,6 +67,7 @@ object GradientUtils {
         {
           if (d < min) colors.head
           else if (d > max) colors.last
+          else if (d.isNaN) RGBA(0,0,0,0)
           else complete(d)
         }
     }
@@ -97,6 +98,7 @@ object GradientUtils {
         val b = interpolate(inverse(b1), inverse(b2), interpolationCoefficient)
         val a = interpolate(a1, a2, interpolationCoefficient)
         RGBA((255 * forward(r)).toInt, (255 * forward(g)).toInt, (255 * forward(b)).toInt, a)
+      case noData if noData.isNaN => RGBA(0,0,0,0)
     }
   }
 


### PR DESCRIPTION
Tiny addition to handle NaN in gradients (as fully transparent). There are likely other places where this could be handled in evilplot, too. I'll fix them as I run across them.