### PR TITLE
Provide native matrix-matrix multiply for ContourPlots

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalacOptions in ThisBuild ++= Settings.scalacOptions
 
 lazy val `evilplot-root` = project
   .in(file("."))
-  .aggregate(evilplotJVM, evilplotJS, evilplotRepl, evilplotJupyterScala, assetJVM, evilplotRunner)
+  .aggregate(evilplotJVM, evilplotJS, evilplotRepl, evilplotJupyterScala, assetJVM, evilplotRunner, mathJS, mathJVM)
   .settings(
     publishArtifact := false,
     publish := {},
@@ -56,6 +56,22 @@ lazy val evilplotAsset = crossProject
 lazy val assetJS = evilplotAsset.js
 lazy val assetJVM = evilplotAsset.jvm
 
+lazy val evilplotMath = crossProject
+  .in(file("math"))
+  .settings(commonSettings)
+  .settings(licenseSettings)
+  .settings(
+    name := "evilplot-math",
+    resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases",
+    libraryDependencies ++= Settings.sharedMathDependencies.value,
+  )
+  .jvmSettings(
+    libraryDependencies ++= Settings.jvmMathDependencies.value
+  )
+
+lazy val mathJS = evilplotMath.js
+lazy val mathJVM = evilplotMath.jvm
+
 lazy val evilplot = crossProject
   .in(file("."))
   .settings(commonSettings)
@@ -78,7 +94,7 @@ lazy val evilplot = crossProject
   )
   .jvmSettings(
     libraryDependencies ++= Settings.jvmDependencies.value
-  )
+  ).dependsOn(evilplotMath)
 
 lazy val evilplotJVM = evilplot.jvm
 lazy val evilplotJS = evilplot.js

--- a/math/js/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
+++ b/math/js/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2018, CiBO Technologies, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.cibo.evilplot.numeric
 
 object MatrixOperations extends MatrixOperationsI {

--- a/math/js/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
+++ b/math/js/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
@@ -1,0 +1,20 @@
+package com.cibo.evilplot.numeric
+
+object MatrixOperations extends MatrixOperationsI {
+
+  def matrixMatrixTransposeMult(
+    a: Array[Array[Double]],
+    b: Array[Array[Double]]): Array[Array[Double]] = {
+    require(
+      a.head.length == b.head.length,
+      "matrix multiplication is not defined for matrices whose" +
+        " inner dimensions are not equal")
+    val innerIndices = a.head.indices
+    Array.tabulate[Double](a.length, b.length) {
+      case (i, j) =>
+        innerIndices.foldLeft(0.0) { (total, k) =>
+          total + a(i)(k) * b(j)(k)
+        }
+    }
+  }
+}

--- a/math/js/src/test/scala/com/cibo/evilplot/numeric/MatrixOperationsSpec.scala
+++ b/math/js/src/test/scala/com/cibo/evilplot/numeric/MatrixOperationsSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, CiBO Technologies, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.cibo.evilplot.numeric
+
+import org.scalatest.{FunSpec, Matchers}
+
+class KernelDensityEstimationSpec extends FunSpec with Matchers {
+  describe("KernelDensityEstimation") {
+
+    it("should properly calculate the matrix product A * B^T") {
+      val a = Array(
+        Array(0.9477583, 0.7026756, 0.0075461, 0.8175592),
+        Array(0.5654393, 0.7140698, 0.5457264, 0.1904566),
+        Array(0.8049051, 0.5844244, 0.5987555, 0.1988892),
+        Array(0.6323643, 0.2691138, 0.7707659, 0.4891442),
+        Array(0.2572372, 0.6319369, 0.2961405, 0.8173221)
+      )
+
+      val b = Array(
+        Array(0.95817, 0.72988, 0.39111, 0.51126),
+        Array(0.42121, 0.98949, 0.41734, 0.76212),
+        Array(0.55427, 0.47121, 0.73324, 0.42507),
+        Array(0.98662, 0.85474, 0.22522, 0.52602),
+        Array(0.94610, 0.54784, 0.21054, 0.92127)
+      )
+
+      val answer = Array(
+        Array(1.8419, 1.7207, 1.2095, 1.9674, 2.0364),
+        Array(1.3738, 1.3176, 1.1310, 1.3913, 1.2165),
+        Array(1.5337, 1.3188, 1.2451, 1.5331, 1.3910),
+        Array(1.3539, 1.2271, 1.2504, 1.2848, 1.3586),
+        Array(1.2414, 1.4801, 1.0049, 1.2906, 1.4049)
+      )
+      val calculatedResult = MatrixOperations.matrixMatrixTransposeMult(a, b).flatten.toSeq
+      (calculatedResult zip answer.flatten.toSeq).foreach {
+        case (calculated, actual) => calculated shouldEqual actual +- 0.003
+      }
+    }
+  }
+}

--- a/math/jvm/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
+++ b/math/jvm/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
@@ -1,0 +1,13 @@
+package com.cibo.evilplot.numeric
+import breeze.linalg.DenseMatrix
+import breeze.util.JavaArrayOps
+
+object MatrixOperations extends MatrixOperationsI {
+  def matrixMatrixTransposeMult(a: Array[Array[Double]], b: Array[Array[Double]]): Array[Array[Double]] = {
+
+    val aMat = JavaArrayOps.array2DToDm(a)
+    val bMat = JavaArrayOps.array2DToDm(b)
+
+    JavaArrayOps.dmDToArray2(aMat * bMat.t)
+  }
+}

--- a/math/jvm/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
+++ b/math/jvm/src/main/scala/com/cibo/evilplot/numeric/MatrixOperations.scala
@@ -1,5 +1,34 @@
+/*
+ * Copyright (c) 2018, CiBO Technologies, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.cibo.evilplot.numeric
-import breeze.linalg.DenseMatrix
 import breeze.util.JavaArrayOps
 
 object MatrixOperations extends MatrixOperationsI {

--- a/math/jvm/src/test/scala/com/cibo/evilplot/numeric/MatrixOperationsSpec.scala
+++ b/math/jvm/src/test/scala/com/cibo/evilplot/numeric/MatrixOperationsSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, CiBO Technologies, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.cibo.evilplot.numeric
+
+import org.scalatest.{FunSpec, Matchers}
+
+class KernelDensityEstimationSpec extends FunSpec with Matchers {
+  describe("KernelDensityEstimation") {
+
+    it("should properly calculate the matrix product A * B^T") {
+      val a = Array(
+        Array(0.9477583, 0.7026756, 0.0075461, 0.8175592),
+        Array(0.5654393, 0.7140698, 0.5457264, 0.1904566),
+        Array(0.8049051, 0.5844244, 0.5987555, 0.1988892),
+        Array(0.6323643, 0.2691138, 0.7707659, 0.4891442),
+        Array(0.2572372, 0.6319369, 0.2961405, 0.8173221)
+      )
+
+      val b = Array(
+        Array(0.95817, 0.72988, 0.39111, 0.51126),
+        Array(0.42121, 0.98949, 0.41734, 0.76212),
+        Array(0.55427, 0.47121, 0.73324, 0.42507),
+        Array(0.98662, 0.85474, 0.22522, 0.52602),
+        Array(0.94610, 0.54784, 0.21054, 0.92127)
+      )
+
+      val answer = Array(
+        Array(1.8419, 1.7207, 1.2095, 1.9674, 2.0364),
+        Array(1.3738, 1.3176, 1.1310, 1.3913, 1.2165),
+        Array(1.5337, 1.3188, 1.2451, 1.5331, 1.3910),
+        Array(1.3539, 1.2271, 1.2504, 1.2848, 1.3586),
+        Array(1.2414, 1.4801, 1.0049, 1.2906, 1.4049)
+      )
+      val calculatedResult = MatrixOperations.matrixMatrixTransposeMult(a, b).flatten.toSeq
+      (calculatedResult zip answer.flatten.toSeq).foreach {
+        case (calculated, actual) => calculated shouldEqual actual +- 0.003
+      }
+    }
+  }
+}

--- a/math/shared/src/main/scala/com/cibo/evilplot/numeric/MatrixOperationsI.scala
+++ b/math/shared/src/main/scala/com/cibo/evilplot/numeric/MatrixOperationsI.scala
@@ -1,0 +1,7 @@
+package com.cibo.evilplot.numeric
+
+trait MatrixOperationsI {
+  def matrixMatrixTransposeMult(
+    a: Array[Array[Double]],
+    b: Array[Array[Double]]): Array[Array[Double]]
+}

--- a/math/shared/src/main/scala/com/cibo/evilplot/numeric/MatrixOperationsI.scala
+++ b/math/shared/src/main/scala/com/cibo/evilplot/numeric/MatrixOperationsI.scala
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2018, CiBO Technologies, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.cibo.evilplot.numeric
 
 trait MatrixOperationsI {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -40,6 +40,20 @@ object Settings {
       "org.jupyter-scala" %% "kernel-api" % versions.jupyterScala % Provided
     ))
 
+  val sharedMathDependencies = Def.setting(
+    Seq(
+      "org.scalactic" %%% "scalactic" % versions.scalactic,
+      "org.scalatest" %%% "scalatest" % versions.scalaTest % "test",
+      compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
+    )
+  )
+
+  val jvmMathDependencies = Def.setting(
+    Seq(
+      "org.scalanlp"               %% "breeze"          % "0.13.2",
+      "org.scalanlp"               %% "breeze-natives"  % "0.13.2", // removing will still work but will be slower
+    ))
+
   val jvmDependencies = Def.setting(
     Seq(
       ))

--- a/shared/src/main/scala/com/cibo/evilplot/numeric/KernelDensityEstimation.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/numeric/KernelDensityEstimation.scala
@@ -56,28 +56,12 @@ object KernelDensityEstimation {
     val xMatrix = kernelMatrix(data.map(_.x).toArray, _xBounds, numXs, spacingX, bandwidthX)
     val yMatrix = kernelMatrix(data.map(_.y).toArray, _yBounds, numYs, spacingY, bandwidthY)
     val denominator = data.length * bandwidthX * bandwidthY
-    val estimate = matrixMatrixTransposeMult(xMatrix, yMatrix).map(_.map(_ / denominator))
+    val estimate = MatrixOperations.matrixMatrixTransposeMult(xMatrix, yMatrix).map(_.map(_ / denominator))
     val zBounds = Bounds(estimate.map(_.min).min, estimate.map(_.max).max)
     assert(
       estimate.length == numXs && estimate.head.length == numYs,
       "density estimate dimensions do not match expectation")
     GridData(estimate.map(_.toVector).toVector, _xBounds, _yBounds, zBounds, spacingX, spacingY)
-  }
-
-  def matrixMatrixTransposeMult(
-    a: Array[Array[Double]],
-    b: Array[Array[Double]]): Array[Array[Double]] = {
-    require(
-      a.head.length == b.head.length,
-      "matrix multiplication is not defined for matrices whose" +
-        " inner dimensions are not equal")
-    val innerIndices = a.head.indices
-    Array.tabulate[Double](a.length, b.length) {
-      case (i, j) =>
-        innerIndices.foldLeft(0.0) { (total, k) =>
-          total + a(i)(k) * b(j)(k)
-        }
-    }
   }
 
   private def kernelMatrix(

--- a/shared/src/test/scala/com/cibo/evilplot/numeric/KernelDensityEstimationSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/numeric/KernelDensityEstimationSpec.scala
@@ -52,35 +52,6 @@ class KernelDensityEstimationSpec extends FunSpec with Matchers {
           probabilityDensityInNormal(x) shouldEqual d +- 1e-5
       }
     }
-    it("should properly calculate the matrix product A * B^T") {
-      val a = Array(
-        Array(0.9477583, 0.7026756, 0.0075461, 0.8175592),
-        Array(0.5654393, 0.7140698, 0.5457264, 0.1904566),
-        Array(0.8049051, 0.5844244, 0.5987555, 0.1988892),
-        Array(0.6323643, 0.2691138, 0.7707659, 0.4891442),
-        Array(0.2572372, 0.6319369, 0.2961405, 0.8173221)
-      )
-
-      val b = Array(
-        Array(0.95817, 0.72988, 0.39111, 0.51126),
-        Array(0.42121, 0.98949, 0.41734, 0.76212),
-        Array(0.55427, 0.47121, 0.73324, 0.42507),
-        Array(0.98662, 0.85474, 0.22522, 0.52602),
-        Array(0.94610, 0.54784, 0.21054, 0.92127)
-      )
-
-      val answer = Array(
-        Array(1.8419, 1.7207, 1.2095, 1.9674, 2.0364),
-        Array(1.3738, 1.3176, 1.1310, 1.3913, 1.2165),
-        Array(1.5337, 1.3188, 1.2451, 1.5331, 1.3910),
-        Array(1.3539, 1.2271, 1.2504, 1.2848, 1.3586),
-        Array(1.2414, 1.4801, 1.0049, 1.2906, 1.4049)
-      )
-      val calculatedResult = KernelDensityEstimation.matrixMatrixTransposeMult(a, b).flatten.toSeq
-      (calculatedResult zip answer.flatten.toSeq).foreach {
-        case (calculated, actual) => calculated shouldEqual actual +- 0.003
-      }
-    }
   }
 
   describe("outer product calculation") {


### PR DESCRIPTION
This PR adds a new cross-built sub-module "evilplotMath" that provides 2 versions of the KernelDensityEstimation's old `matrixMatrixTransposeMult` function. 

The JS version is the old @zacharygraziano pure-Scala implementation (which can be to-js-transpiled), and the JVM version is now backed by Breeze matrix ops (after a goodly amount of array-copying 😢). This change also includes the `breeze-natives` JAR in the JVM dependencies which will use native extensions for that matrix-matrix multiply.

For contour plots, which may occur frequently in for instance, pairs-plots, on my system this decreases render time by 50%.

I moved and replicated the original tests for this method into both the JVM and JS directories (I think that will test the respective implementations?). All top-level tests pass on my system (though I'm not sure if/how to run IT tests?).