### PR TITLE
* change Seq to Vector

### DIFF
--- a/shared/src/main/scala/com/cibo/evilplot/geometry/package.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/geometry/package.scala
@@ -120,7 +120,7 @@ package object geometry {
 
     def group: Drawable = {
       // Flatten nested groups.
-      val flattened = drawables.foldLeft(Seq.empty[Drawable]) { (ds, d) =>
+      val flattened = drawables.foldLeft(Vector.empty[Drawable]) { (ds, d) =>
         d match {
           case Group(inner)    => ds ++ inner
           case EmptyDrawable() => ds


### PR DESCRIPTION
This seems like a tiny little change, but on my system on a particular real-world test case, improves rendering performance by 75% (4 minutes --> 1 minute).

This `foldLeft` folds over a `Seq` which is subsequently appended to potentially _many_ times. Appending to the default collection `List` is unfortunately incredibly slow (its actually N-time where N is the length of the `List`! See: https://docs.scala-lang.org/overviews/collections/performance-characteristics.html), and Lists should not be used in performance-critical code which does appends. Now we know that this is actually performance critical in some situations!