### PR TITLE
Added cross-build for Scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target/
 asset/
 *.iml
+.bloop/
 .cache
 .classpath
 .metals/

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ asset/
 *.iml
 .cache
 .classpath
+.metals/
 .project
 .settings/
 .idea/
 .DS_Store
 node_modules
+project/.bloop
 repl-plots/src/main/scala/com/cibo/evilplot/test.scala
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ asset/
 node_modules
 project/.bloop
 repl-plots/src/main/scala/com/cibo/evilplot/test.scala
-
+project/metals.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
         - $HOME/.sbt/boot/
 
 script:
-    - sbt ++$TRAVIS_SCALA_VERSION -J-Xms512M -J-Xmx2G -J-Xss2M -J-XX:MaxMetaspaceSize=1024M scalastyle test headerCheck test:headerCheck it:test doc
+    - sbt ++$TRAVIS_SCALA_VERSION -J-Xms512M -J-Xmx2G -J-Xss2M -J-XX:MaxMetaspaceSize=1024M scalastyle +test headerCheck test:headerCheck +it:test doc
 
 notifications:
-  email: false
+    email: false

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val evilplotMath = crossProject
   .settings(licenseSettings)
   .settings(
     name := "evilplot-math",
-    resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases",
+    resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases",
     libraryDependencies ++= Settings.sharedMathDependencies.value
   )
   .jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   licenses += ("BSD 3-Clause", url("https://opensource.org/licenses/BSD-3-Clause"))
 )
 
+// Macroparadise is included in scala 2.13. Do contortion here for 2.12/2.13 crossbuild
 Compile / scalacOptions ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,16 @@ scalacOptions in ThisBuild ++= Settings.scalacOptions
 
 lazy val `evilplot-root` = project
   .in(file("."))
-  .aggregate(evilplotJVM, evilplotJS, evilplotRepl, evilplotJupyterScala, assetJVM, evilplotRunner, mathJS, mathJVM)
+  .aggregate(
+    evilplotJVM,
+    evilplotJS,
+    evilplotRepl,
+    evilplotJupyterScala,
+    assetJVM,
+    evilplotRunner,
+    mathJS,
+    mathJVM
+  )
   .settings(
     publishArtifact := false,
     publish := {},
@@ -31,14 +40,15 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
 Compile / scalacOptions ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
-    case _ => Nil
+    case _                       => Nil
   }
 }
 
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, n)) if n >= 13 => Nil
-    case _ => compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
+    case _ =>
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
   }
 }
 
@@ -78,7 +88,7 @@ lazy val evilplotMath = crossProject
   .settings(
     name := "evilplot-math",
     resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases",
-    libraryDependencies ++= Settings.sharedMathDependencies.value,
+    libraryDependencies ++= Settings.sharedMathDependencies.value
   )
   .jvmSettings(
     libraryDependencies ++= Settings.jvmMathDependencies.value
@@ -109,7 +119,8 @@ lazy val evilplot = crossProject
   )
   .jvmSettings(
     libraryDependencies ++= Settings.jvmDependencies.value
-  ).dependsOn(evilplotMath)
+  )
+  .dependsOn(evilplotMath)
 
 lazy val evilplotJVM = evilplot.jvm
 lazy val evilplotJS = evilplot.js
@@ -141,18 +152,20 @@ lazy val evilplotJupyterScala = project
   .settings(licenseSettings)
   .settings(
     name := "evilplot-jupyter-scala",
-    libraryDependencies ++= Settings.jupyterScalaDependencies.value
+    libraryDependencies ++= Settings.jupyterScalaDependencies.value,
+    resolvers += "jitpack" at "https://jitpack.io"
   )
 
 val EvilPlotJVM = config("jvm")
 val EvilPlotJS = config("js")
 lazy val apiDocProjects = Seq(evilplotJVM -> EvilPlotJVM, evilplotJS -> EvilPlotJS)
-lazy val apiDocumentation = apiDocProjects.flatMap { case (project, conf) =>
-  SiteScaladocPlugin.scaladocSettings(
-    conf,
-    mappings in (Compile, packageDoc) in project,
-    s"scaladoc/${project.id.stripPrefix("evilplot").toLowerCase}"
-  )
+lazy val apiDocumentation = apiDocProjects.flatMap {
+  case (project, conf) =>
+    SiteScaladocPlugin.scaladocSettings(
+      conf,
+      mappings in (Compile, packageDoc) in project,
+      s"scaladoc/${project.id.stripPrefix("evilplot").toLowerCase}"
+    )
 }
 
 lazy val docs = project

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,20 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   licenses += ("BSD 3-Clause", url("https://opensource.org/licenses/BSD-3-Clause"))
 )
 
+Compile / scalacOptions ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
+    case _ => Nil
+  }
+}
+
+libraryDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 13 => Nil
+    case _ => compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full) :: Nil
+  }
+}
+
 lazy val licenseSettings = Seq(
   homepage := Some(url("https://www.github.com/cibotech/evilplot")),
   startYear := Some(2018),
@@ -41,7 +55,7 @@ lazy val evilplotAsset = crossProject
   .settings(licenseSettings)
   .settings(
     name := "evilplot-asset",
-    resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
+    resolvers += "Artima Maven Repository" at "https://repo.artima.com/releases"
   )
   .jvmSettings(
     resourceGenerators.in(Compile) += Def.task {

--- a/js/src/main/scala/com/cibo/evilplot/DemoScatterInteraction.scala
+++ b/js/src/main/scala/com/cibo/evilplot/DemoScatterInteraction.scala
@@ -129,9 +129,10 @@ object DemoAreaInteraction {
 
     val canvasId = UUID.randomUUID().toString
 
-    val points = (0.0 to 10.0 by 0.1).map(x => Point(x, Math.cos(x)))
-    val pointslower = (0.0 to 10.0 by 0.1).map(x => Point(x, Math.cos(x) - 0.15))
-    val pointsUpper = (0.0 to 10.0 by 0.1).map(x => Point(x, Math.cos(x) + 0.15))
+    val xs = Range.BigDecimal(0, 10, 0.1).map(_.toDouble)
+    val points = xs.map(x => Point(x, Math.cos(x)))
+    val pointslower = xs.map(x => Point(x, Math.cos(x) - 0.15))
+    val pointsUpper = xs.map(x => Point(x, Math.cos(x) + 0.15))
 
 
     def plotFromData(middle: Seq[Point], upper: Seq[Point], lower: Seq[Point], plotExtent: Extent): Drawable = CartesianPlot(middle)(

--- a/jupyter-scala/src/main/scala/com/cibo/evilplot/JupyterScala.scala
+++ b/jupyter-scala/src/main/scala/com/cibo/evilplot/JupyterScala.scala
@@ -30,6 +30,8 @@
 
 package com.cibo.evilplot
 
+
+import almond.display.Image
 import com.cibo.evilplot.plot.Plot
 import com.cibo.evilplot.geometry.Drawable
 import com.cibo.evilplot.plot.aesthetics.Theme
@@ -41,15 +43,16 @@ object JupyterScala {
   implicit class JupyterScalaDrawableMethods(drawable: Drawable) {
 
     /** display this Drawable object directly in the jupyter-scala output cell */
-    def show(implicit publish: jupyter.api.Publish): Unit =
-      publish.png(drawable.asBufferedImage)
+    def show(): Unit =
+      Image.fromRenderedImage(drawable.asBufferedImage, Image.PNG)
+
   }
 
   /** enhanced methods on Plot objects for jupyter-scala */
   implicit class JupyterScalaPlotMethods(plot: Plot) {
 
     /** display this Plot object directly in the jupyter-scala output cell */
-    def show(implicit publish: jupyter.api.Publish, theme: Theme): Unit =
-      publish.png(plot.render()(theme).asBufferedImage)
+    def show(implicit theme: Theme): Unit =
+      Image.fromRenderedImage(plot.render()(theme).asBufferedImage, Image.PNG)
   }
 }

--- a/jvm/src/main/scala/com/cibo/evilplot/geometry/Graphics2DSupport.scala
+++ b/jvm/src/main/scala/com/cibo/evilplot/geometry/Graphics2DSupport.scala
@@ -113,7 +113,7 @@ final case class Graphics2DRenderContext(graphics: Graphics2D)
     graphics.draw(gpath)
   }
 
-  def draw(polygon: Polygon): Unit = applyWithFillColor(this) {
+  def draw(polygon: com.cibo.evilplot.geometry.Polygon): Unit = applyWithFillColor(this) {
     val gpath = new GeneralPath()
     gpath.moveTo(polygon.boundary.head.x, polygon.boundary.head.y)
     polygon.boundary.tail.foreach { point =>

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -18,9 +18,9 @@ object Settings {
     val crossScalaVersions = Seq("2.12.10", "2.13.1")
     val scalaDom = "0.9.8"
     val scalaTest = "3.0.8"
-    val scalactic = "3.1.0"
+    val scalactic = "3.0.8"
     val scopt = "3.5.0"
-    val circe = "0.12.2"
+    val circe = "0.13.0"
     val jupyterScala = "0.4.1"
     val scalacheck = "1.14.3"
   }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -40,7 +40,8 @@ object Settings {
   val jupyterScalaDependencies = Def.setting(
     Seq(
       // "org.jupyter-scala" %% "kernel-api" % versions.jupyterScala % Provided
-      ("sh.almond" % "scala-kernel-api" % "0.9.1" % "provided").cross(CrossVersion.full)
+//      ("sh.almond" % "jupyter-api" % "0.9.1" % "provided").cross(CrossVersion.full)
+      "sh.almond" %% "jupyter-api" % "0.9.1" % "provided"
     )
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -31,44 +31,45 @@ object Settings {
       "io.circe" %%% "circe-generic" % versions.circe,
       "io.circe" %%% "circe-parser" % versions.circe,
       "io.circe" %%% "circe-generic-extras" % versions.circe,
-      "org.scalactic" %% "scalactic" % versions.scalactic,
-      "org.scalacheck" %% "scalacheck" % versions.scalacheck % "test",
-      "org.scalatest" %% "scalatest" % versions.scalaTest % "it,test",
-//      compilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full)
-    ))
+      "org.scalactic" %%% "scalactic" % versions.scalactic,
+      "org.scalacheck" %%% "scalacheck" % versions.scalacheck % "test",
+      "org.scalatest" %%% "scalatest" % versions.scalaTest % "it,test"
+    )
+  )
 
   val jupyterScalaDependencies = Def.setting(
     Seq(
       "org.jupyter-scala" %% "kernel-api" % versions.jupyterScala % Provided
-    ))
-
-
-
-  val sharedMathDependencies = Def.setting(
-    Seq(
-      "org.scalactic" %% "scalactic" % versions.scalactic,
-      "org.scalatest" %% "scalatest" % versions.scalaTest % "test",
-//      compilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.Full)
     )
   )
 
+  val sharedMathDependencies = Def.setting(
+    Seq(
+      "org.scalactic" %%% "scalactic" % versions.scalactic,
+      "org.scalatest" %%% "scalatest" % versions.scalaTest % "test"
+    )
+  )
 
   val jvmMathDependencies = Def.setting(
     Seq(
-      "org.scalanlp"               %% "breeze"          % "1.0",
-      "org.scalanlp"               %% "breeze-natives"  % "1.0", // removing will still work but will be slower
-    ))
+      "org.scalanlp" %% "breeze" % "1.0",
+      "org.scalanlp" %% "breeze-natives" % "1.0" // removing will still work but will be slower
+    )
+  )
 
   val jvmDependencies = Def.setting(
     Seq(
-      ))
+      )
+  )
 
   val scalajsDependencies = Def.setting(
     Seq(
       "org.scala-js" %%% "scalajs-dom" % versions.scalaDom
-    ))
+    )
+  )
 
   val jsDependencies = Def.setting(
     Seq(
-      ))
+      )
+  )
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,5 +1,6 @@
 import sbt._
-import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+//import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Settings {
   val organization = "com.cibo"
@@ -14,14 +15,14 @@ object Settings {
   )
 
   object versions { //scalastyle:ignore
-    val crossScalaVersions = Seq("2.12.4")
-    val scalaDom = "0.9.3"
-    val scalaTest = "3.0.7"
-    val scalactic = "3.0.7"
+    val crossScalaVersions = Seq("2.12.10", "2.13.1")
+    val scalaDom = "0.9.8"
+    val scalaTest = "3.1.0"
+    val scalactic = "3.1.0"
     val scopt = "3.5.0"
-    val circe = "0.9.0"
+    val circe = "0.12.2"
     val jupyterScala = "0.4.1"
-    val scalacheck = "1.14.0"
+    val scalacheck = "1.14.2"
   }
 
   val sharedDependencies = Def.setting(
@@ -30,10 +31,10 @@ object Settings {
       "io.circe" %%% "circe-generic" % versions.circe,
       "io.circe" %%% "circe-parser" % versions.circe,
       "io.circe" %%% "circe-generic-extras" % versions.circe,
-      "org.scalactic" %%% "scalactic" % versions.scalactic,
-      "org.scalacheck" %%% "scalacheck" % versions.scalacheck % "test",
-      "org.scalatest" %%% "scalatest" % versions.scalaTest % "it,test",
-      compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
+      "org.scalactic" %% "scalactic" % versions.scalactic,
+      "org.scalacheck" %% "scalacheck" % versions.scalacheck % "test",
+      "org.scalatest" %% "scalatest" % versions.scalaTest % "it,test",
+//      compilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full)
     ))
 
   val jupyterScalaDependencies = Def.setting(
@@ -41,18 +42,21 @@ object Settings {
       "org.jupyter-scala" %% "kernel-api" % versions.jupyterScala % Provided
     ))
 
+
+
   val sharedMathDependencies = Def.setting(
     Seq(
-      "org.scalactic" %%% "scalactic" % versions.scalactic,
-      "org.scalatest" %%% "scalatest" % versions.scalaTest % "test",
-      compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
+      "org.scalactic" %% "scalactic" % versions.scalactic,
+      "org.scalatest" %% "scalatest" % versions.scalaTest % "test",
+//      compilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.Full)
     )
   )
 
+
   val jvmMathDependencies = Def.setting(
     Seq(
-      "org.scalanlp"               %% "breeze"          % "0.13.2",
-      "org.scalanlp"               %% "breeze-natives"  % "0.13.2", // removing will still work but will be slower
+      "org.scalanlp"               %% "breeze"          % "1.0",
+      "org.scalanlp"               %% "breeze-natives"  % "1.0", // removing will still work but will be slower
     ))
 
   val jvmDependencies = Def.setting(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -39,7 +39,8 @@ object Settings {
 
   val jupyterScalaDependencies = Def.setting(
     Seq(
-      "org.jupyter-scala" %% "kernel-api" % versions.jupyterScala % Provided
+      // "org.jupyter-scala" %% "kernel-api" % versions.jupyterScala % Provided
+      ("sh.almond" % "scala-kernel-api" % "0.9.1" % "provided").cross(CrossVersion.full)
     )
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -22,7 +22,7 @@ object Settings {
     val scopt = "3.5.0"
     val circe = "0.12.2"
     val jupyterScala = "0.4.1"
-    val scalacheck = "1.14.2"
+    val scalacheck = "1.14.3"
   }
 
   val sharedDependencies = Def.setting(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -17,7 +17,7 @@ object Settings {
   object versions { //scalastyle:ignore
     val crossScalaVersions = Seq("2.12.10", "2.13.1")
     val scalaDom = "0.9.8"
-    val scalaTest = "3.1.0"
+    val scalaTest = "3.0.8"
     val scalactic = "3.1.0"
     val scopt = "3.5.0"
     val circe = "0.12.2"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.5
+sbt.version=1.3.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,18 +1,19 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
-dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.22"
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
+dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.31"
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 //addSbtPlugin("com.lihaoyi" % "workbench" % "0.4.1")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.18")
 
 dependencyOverrides ++= Seq(
-  "org.scala-js" % "sbt-scalajs" % "0.6.22",
-  "com.typesafe.akka" %% "akka-actor" % "2.4.19",
-  "com.typesafe.akka" %% "akka-stream" % "2.4.19"
+  "org.scala-js" % "sbt-scalajs" % "0.6.31",
+  "com.typesafe.akka" %% "akka-actor" % "2.6.1",
+  "com.typesafe.akka" %% "akka-stream" % "2.6.1"
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,19 +1,18 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.4.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")
-dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.31"
+dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.32"
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 //addSbtPlugin("com.lihaoyi" % "workbench" % "0.4.1")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.18")
 
 dependencyOverrides ++= Seq(
-  "org.scala-js" % "sbt-scalajs" % "0.6.31",
+  "org.scala-js" % "sbt-scalajs" % "0.6.32",
   "com.typesafe.akka" %% "akka-actor" % "2.6.1",
   "com.typesafe.akka" %% "akka-stream" % "2.6.1"
 )
-

--- a/shared/src/main/scala/com/cibo/evilplot/colors/ColorUtils.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/colors/ColorUtils.scala
@@ -40,7 +40,8 @@ object ColorUtils {
     min: Double,
     red: Double,
     green: Double,
-    blue: Double): Double = {
+    blue: Double
+  ): Double = {
     if (max == min) {
       0.0
     } else {
@@ -114,7 +115,8 @@ object ColorUtils {
   private[colors] def interpolate(
     component1: Double,
     component2: Double,
-    coefficient: Double): Double = {
+    coefficient: Double
+  ): Double = {
     component1 * (1 - coefficient) + coefficient * component2
   }
 

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -1,44 +1,13 @@
-/*
- * Copyright (c) 2018, CiBO Technologies, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors
- *    may be used to endorse or promote products derived from this software without
- *    specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package com.cibo.evilplot.demo
 
 import com.cibo.evilplot.colors._
-import com.cibo.evilplot.geometry._
-import com.cibo.evilplot.numeric._
-import com.cibo.evilplot.{geometry, plot}
-import com.cibo.evilplot.plot._
+import com.cibo.evilplot.geometry.{Align, Disc, Drawable, Extent, LineStyle, LinearGradient, Rect, Rotate, Style, Text, Wedge}
+import com.cibo.evilplot.numeric.{Bounds, Datum2d, Point, Point3d}
 import com.cibo.evilplot.plot.aesthetics.DefaultTheme.{DefaultFonts, DefaultTheme}
 import com.cibo.evilplot.plot.aesthetics.Theme
 import com.cibo.evilplot.plot.components.{Legend, Marker, Position}
 import com.cibo.evilplot.plot.renderers._
+import com.cibo.evilplot.plot.{Bar, BarChart, BinnedPlot, BoxPlot, CartesianPlot, Facets, FunctionPlot, Heatmap, Histogram, LegendContext, LegendStyle, LinePlot, MixedBoundsOverlay, Overlay, PieChart, Plot, PlotContext, ScatterPlot}
 
 import scala.util.Random
 
@@ -73,7 +42,10 @@ object DemoPlots {
   val plotAreaSize: Extent = Extent(1000, 600)
   lazy val histogram: Drawable = {
     Random.setSeed(666L) //evil seed
-    val data = (0.0 to 3 by .25) ++ (3.0 to 5 by .05) ++ (5.0 to 8 by 1.0)
+
+    val data = (Range.BigDecimal(0, 3, .25) ++
+      Range.BigDecimal(3, 5, .05) ++
+      Range.BigDecimal(5, 8, 1)).map(_.toDouble)
 
     Histogram(data, 10)
       .standard()
@@ -339,7 +311,9 @@ object DemoPlots {
       def withXY(x: Double, y: Double): MultiValuePoint = this.copy(x = x, y = y)
     }
 
-    val points = (0.0 to 10.0 by 0.1).map(x => MultiValuePoint(x, Math.cos(x) + x / 2, Math.sin(x) + x, x))
+    val points = Range.BigDecimal(0, 10, 0.1)
+      .map(_.toDouble)
+      .map(x => MultiValuePoint(x, Math.cos(x) + x / 2, Math.sin(x) + x, x))
 
     CartesianPlot[MultiValuePoint](points)(
       _.reducePoint(_.y).areaToYBound(HTMLNamedColors.blue, fillToY = Some(0.0)),
@@ -353,9 +327,10 @@ object DemoPlots {
   }
 
   lazy val ribbonPlot: Drawable = {
-    val points = (0.0 to 10.0 by 0.1).map(x => Point(x, Math.cos(x)))
-    val pointslower = (0.0 to 10.0 by 0.1).map(x => Point(x, Math.cos(x) - 0.15))
-    val pointsUpper = (0.0 to 10.0 by 0.1).map(x => Point(x, Math.cos(x) + 0.15))
+    val xs = Range.BigDecimal(0, 10, .1).map(_.toDouble)
+    val points = xs.map(x => Point(x, Math.cos(x)))
+    val pointslower = xs.map(x => Point(x, Math.cos(x) - 0.15))
+    val pointsUpper = xs.map(x => Point(x, Math.cos(x) + 0.15))
 
     CartesianPlot(points)(
       _.line(color = HTMLNamedColors.white),
@@ -369,7 +344,9 @@ object DemoPlots {
   }
 
   lazy val areaPlotGradient: Drawable = {
-    val points = (0.0 to 10.0 by 0.1).map(x => Point(x, Math.cos(x)))
+    val points = Range.BigDecimal(0, 10, .1)
+      .map(_.toDouble)
+      .map(x => Point(x, Math.cos(x)))
 
     val gradientFnMiddle = { ctx: PlotContext =>
       LinearGradient.topToBottom(ctx.extent, FillGradients.distributeEvenly(ColorGradients.inferno.reverse ++ ColorGradients.inferno ))

--- a/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
+++ b/shared/src/main/scala/com/cibo/evilplot/demo/DemoPlots.scala
@@ -1,3 +1,33 @@
+/*
+ * Copyright (c) 2018, CiBO Technologies, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.cibo.evilplot.demo
 
 import com.cibo.evilplot.colors._

--- a/shared/src/test/scala/com/cibo/evilplot/colors/ColoringSpec.scala
+++ b/shared/src/test/scala/com/cibo/evilplot/colors/ColoringSpec.scala
@@ -43,7 +43,9 @@ class ColoringSpec extends FunSpec with Matchers {
       val max: Double = 100
       val coloring =
         GradientUtils.multiGradient(Seq(HTMLNamedColors.blue), min, max, GradientMode.Linear)
-      (min to max by 1.0).foreach(datum => coloring(datum) shouldBe HTMLNamedColors.blue)
+      Range.BigDecimal(min, max, 1.0)
+        .map(_.toDouble)
+        .foreach(datum => coloring(datum) shouldBe HTMLNamedColors.blue)
     }
 
     it("should throw an exception when Colors is empty") {


### PR DESCRIPTION
I've added a cross-build for Scala 2.13 and upgraded evilplot's dependencies. Everything compiles and tests pass. I'd like to hand the code over to the maintainers to decide what to do with it. Note that jupyter-scala is no longer supported, so I migrated evilplot to use [almond.sh](https://almond.sh/) instead. This is for issue #95 