### PR TITLE
Revert circe version, release 0.7.1, don't merge

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,12 +15,12 @@ object Settings {
   )
 
   object versions { //scalastyle:ignore
-    val crossScalaVersions = Seq("2.12.10", "2.13.1")
+    val crossScalaVersions = Seq("2.12.10")
     val scalaDom = "0.9.8"
     val scalaTest = "3.0.8"
     val scalactic = "3.0.8"
     val scopt = "3.5.0"
-    val circe = "0.13.0"
+    val circe = "0.9.3"
     val jupyterScala = "0.4.1"
     val scalacheck = "1.14.3"
   }

--- a/release.sbt
+++ b/release.sbt
@@ -3,7 +3,6 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
-  runTest,
   releaseStepCommand("headerCheck"),
   setReleaseVersion,
   commitReleaseVersion,

--- a/release.sbt
+++ b/release.sbt
@@ -10,8 +10,7 @@ releaseProcess := Seq[ReleaseStep](
   tagRelease,
   publishArtifacts,
   setNextVersion,
-  commitNextVersion,
-  pushChanges
+  commitNextVersion
 )
 
 releaseCrossBuild := true

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.1-SNAPSHOT"
+version in ThisBuild := "0.7.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.1"
+version in ThisBuild := "0.7.2-SNAPSHOT"


### PR DESCRIPTION
Reverted to circe 0.9.3 to resolve an internal inconsistency at CiBO.
Released it as 0.7.1, with no cross build.
No intention to merge this; just want to have this as a point of reference for anyone confused why there's a 0.7.1.