### PR TITLE
Set version.sbt to 0.8.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ EvilPlot is about combinators for graphics.
 
 Documentation for EvilPlot is available [here](https://cibotech.github.io/evilplot).
 
+See all versions [on Bintray](https://bintray.com/beta/#/cibotech/public/evilplot?tab=overview)
+
 ## Getting Started
 Add EvilPlot to your build with:
 ```scala

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.1-SNAPSHOT"
+version in ThisBuild := "0.8.1-SNAPSHOT"


### PR DESCRIPTION
The greatest published version is 0.8.0. I guess when that was published there was some misconfiguration that prevented the version getting bumped. 

Also, a bit confusing, I published a version 0.7.1 with some older dependencies about a week ago. That seems to show up as the "latest" version on the Download badge. So I added a link to Bintray where people can view all the versions.