### PR TITLE
Make sure scalactic dependency doesn't leak to downstream projects 

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,9 +8,9 @@ name: Scala CI
 on:
   workflow_dispatch:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -41,7 +41,7 @@ object Settings {
 
   val sharedMathDependencies = Def.setting(
     Seq(
-      "org.scalactic" %%% "scalactic" % versions.scalactic,
+      "org.scalactic" %%% "scalactic" % versions.scalactic % "test",
       "org.scalatest" %%% "scalatest" % versions.scalaTest % "test"
     )
   )
@@ -55,7 +55,7 @@ object Settings {
 
   val jvmDependencies = Def.setting(
     Seq(
-      "org.scalactic" %%% "scalactic" % versions.scalactic,
+      "org.scalactic" %%% "scalactic" % versions.scalactic % "test",
       "org.scalatestplus" %% "scalacheck-1-17" % "3.2.15.0" % "test",
       )
   )


### PR DESCRIPTION
Redoing #146 because CI did weird things.

It looks like for a while now, the scalactic dependency has been erroneously marked as needed for runtime, rather than just for tests. This causes the scalactic version specified here to leak to any code that depends on evilplot. Since scalatest is marked as test-only in the dependencies here, this can cause scalatest and scalactic versions to go out of sync in downstream code, causing confusing compile errors. It seems like this issue has gone unnoticed because up until evilplot 0.9.0, we were using a fairly old version of scalatest; when we updated scalatest to 3.2.15, now suddenly we're overriding downstream code with a newer version of scalactic.

(For CIBO folks, https://github.com/cibotech/salus-one/pull/1197#discussion_r1389566666 for some more context.)