### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Changes since last release]
 
+## [0.9.1] - 2023-11-15
+### Fixed
+- scalactic dependency version no longer leaks to downstream projects
+
 ## [0.9.0] - 2023-06-21
 ### Added
 #Changed

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.9.1"
+ThisBuild / version := "0.9.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.9.1-SNAPSHOT"
+ThisBuild / version := "0.9.1"


### PR DESCRIPTION
This is a small patch release to prevent the scalactic dependency from leaking to downstream code.

Since no new features were added, there's no need to update the GH pages documentation site.